### PR TITLE
Add Markov chain value model demo for StatsBomb open data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# Football_Analytics_JCproject
-# Football_Analytics_JCproject
+# Football Analytics Markov Model Demo
+
+This repository contains a single-script demo that downloads StatsBomb's open
+data and builds a Markov chain model inspired by Ian Graham's possession value
+work. The output is an interactive Plotly heatmap that lets you explore how the
+value of different on-ball actions changes across the pitch.
+
+## Quick start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python markov_value_model.py --max-matches 20 --output value_model.html
+```
+
+The script saves an HTML file (`value_model.html` by default) containing the
+interactive visualisation, which you can embed directly into a presentation.
+
+### Command line options
+
+* `--competition` – StatsBomb competition ID (default: `43`, 2018 World Cup).
+* `--season` – Season ID for the chosen competition (default: `3`).
+* `--max-matches` – Limit the number of matches downloaded to keep the example
+  lightweight.
+* `--output` – Path to write the interactive Plotly HTML file.
+
+The dropdown menu in the resulting figure includes:
+
+* **State Value** – probability of scoring before the possession ends from each
+  zone (the Ian Graham-style possession value).
+* **Discounted Value** – an RL-inspired variant with a discount factor that
+  emphasises quicker scoring opportunities.
+* **Action Value** heatmaps – expected goal value if a possession chooses a
+  specific action (pass, carry, shot, etc.) from each zone.
+* **Action Advantage** heatmaps – the improvement over the average action in
+  that zone, analogous to an RL advantage function.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This repository contains a single-script demo that downloads StatsBomb's open
 data and builds a Markov chain model inspired by Ian Graham's possession value
-work. The output is an interactive Plotly heatmap that lets you explore how the
-value of different on-ball actions changes across the pitch.
+work. The refreshed version adds higher-resolution pitch grids, goal markers,
+support-context modelling from StatsBomb 360 freeze frames and additional
+visualisations for presentations (interactive and static).
 
 ## Quick start
 
@@ -11,11 +12,18 @@ value of different on-ball actions changes across the pitch.
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-python markov_value_model.py --max-matches 20 --output value_model.html
+python markov_value_model.py --max-matches 20
 ```
 
-The script saves an HTML file (`value_model.html` by default) containing the
-interactive visualisation, which you can embed directly into a presentation.
+The script saves multiple outputs by default:
+
+* `value_model.html` – interactive Plotly heatmap of state/action values.
+* `value_model.png` – static Matplotlib summary of key value surfaces.
+* `support_value.html` – contextual model that folds StatsBomb 360 player
+  positions into the state (falls back gracefully if freeze frames are
+  unavailable).
+* `ball_progression.png` – quiver plot describing average pass/carry movement.
+* `shot_quality.html` – heatmap of goal probability by shot distance/angle.
 
 ### Command line options
 
@@ -24,8 +32,12 @@ interactive visualisation, which you can embed directly into a presentation.
 * `--max-matches` – Limit the number of matches downloaded to keep the example
   lightweight.
 * `--output` – Path to write the interactive Plotly HTML file.
+* `--static-output` – File path for the static Matplotlib summary.
+* `--support-output` – Where to save the support-context HTML visualisation.
+* `--progression-output` – Output path for the quiver plot.
+* `--shot-output` – File path for the shot quality heatmap.
 
-The dropdown menu in the resulting figure includes:
+The dropdown menu in the interactive figure includes:
 
 * **State Value** – probability of scoring before the possession ends from each
   zone (the Ian Graham-style possession value).
@@ -35,3 +47,13 @@ The dropdown menu in the resulting figure includes:
   specific action (pass, carry, shot, etc.) from each zone.
 * **Action Advantage** heatmaps – the improvement over the average action in
   that zone, analogous to an RL advantage function.
+
+The support-context visualisation groups states by the on-ball player's help:
+isolated versus supported, pressure levels and whether a progressive passing
+lane exists. These states are derived from StatsBomb 360 freeze frames, so the
+plot only appears for competitions where those data are available.
+
+The static PNG and quiver plot add presentation-friendly slides for exploring
+action values and ball movement without relying on interactive controls. The
+shot quality heatmap complements the possession model by answering "what kinds
+of shots score most often?" in terms of distance and shooting angle.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
-# Football Analytics Markov Model Demo
+# StatsBomb 360 Markov Chain Visualiser
 
-This repository contains a single-script demo that downloads StatsBomb's open
-data and builds a Markov chain model inspired by Ian Graham's possession value
-work. The refreshed version adds higher-resolution pitch grids, goal markers,
-support-context modelling from StatsBomb 360 freeze frames and additional
-visualisations for presentations (interactive and static).
+This repository keeps everything in a single Python script that pulls directly
+from [StatsBomb's open data](https://github.com/statsbomb/open-data) and builds a
+transparent Markov decision process (MDP) style value model. Every state uses
+StatsBomb 360 freeze-frame player locations so you can literally watch the value
+surface emerge event by event.
+
+## What the script does
+
+* downloads competitions, matches and events until it finds ones with StatsBomb
+  360 freeze frames (no other data sources are used)
+* builds a pitch grid and initialises the value function at zero
+* treats each freeze-framed event as a state whose features are the teammate and
+  opponent locations plus the ball position
+* updates the value grid sequentially with a temporal-difference rule so you can
+  step through the creation of the Markov value model
+* draws every player and the ball on a stylised pitch alongside the evolving
+  value surface
+* saves the result as a Plotly HTML animation where you can scrub through or
+  autoplay the match
 
 ## Quick start
 
@@ -12,48 +26,27 @@ visualisations for presentations (interactive and static).
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-python markov_value_model.py --max-matches 20
+python markov_value_model.py --max-matches 10
 ```
 
-The script saves multiple outputs by default:
+The script prints the path to the generated HTML file (default
+`three_sixty_markov.html`). Open it in a browser to step through each event.
 
-* `value_model.html` – interactive Plotly heatmap of state/action values.
-* `value_model.png` – static Matplotlib summary of key value surfaces.
-* `support_value.html` – contextual model that folds StatsBomb 360 player
-  positions into the state (falls back gracefully if freeze frames are
-  unavailable).
-* `ball_progression.png` – quiver plot describing average pass/carry movement.
-* `shot_quality.html` – heatmap of goal probability by shot distance/angle.
+## Useful command-line options
 
-### Command line options
+* `--list` – show the matches (within the search limits) that include 360 data
+  and exit
+* `--match-id` – render a specific match that is known to have StatsBomb 360
+  freeze frames
+* `--competition-id` / `--season-id` – filter the search to a particular
+  competition and season
+* `--max-matches` – limit how many matches are checked for 360 data (default 5)
+* `--grid-x` / `--grid-y` – control the pitch discretisation used for the value
+  function
+* `--gamma` / `--alpha` – tweak the temporal-difference discount factor and
+  learning rate
+* `--output` – choose a different HTML file name
 
-* `--competition` – StatsBomb competition ID (default: `43`, 2018 World Cup).
-* `--season` – Season ID for the chosen competition (default: `3`).
-* `--max-matches` – Limit the number of matches downloaded to keep the example
-  lightweight.
-* `--output` – Path to write the interactive Plotly HTML file.
-* `--static-output` – File path for the static Matplotlib summary.
-* `--support-output` – Where to save the support-context HTML visualisation.
-* `--progression-output` – Output path for the quiver plot.
-* `--shot-output` – File path for the shot quality heatmap.
-
-The dropdown menu in the interactive figure includes:
-
-* **State Value** – probability of scoring before the possession ends from each
-  zone (the Ian Graham-style possession value).
-* **Discounted Value** – an RL-inspired variant with a discount factor that
-  emphasises quicker scoring opportunities.
-* **Action Value** heatmaps – expected goal value if a possession chooses a
-  specific action (pass, carry, shot, etc.) from each zone.
-* **Action Advantage** heatmaps – the improvement over the average action in
-  that zone, analogous to an RL advantage function.
-
-The support-context visualisation groups states by the on-ball player's help:
-isolated versus supported, pressure levels and whether a progressive passing
-lane exists. These states are derived from StatsBomb 360 freeze frames, so the
-plot only appears for competitions where those data are available.
-
-The static PNG and quiver plot add presentation-friendly slides for exploring
-action values and ball movement without relying on interactive controls. The
-shot quality heatmap complements the possession model by answering "what kinds
-of shots score most often?" in terms of distance and shooting angle.
+Because the animation is driven entirely by StatsBomb 360 freeze frames, some
+competitions will not appear unless they have that extra contextual data. Use
+`--list` to confirm availability before rendering.

--- a/markov_value_model.py
+++ b/markov_value_model.py
@@ -1,0 +1,357 @@
+"""Simple Markov chain value model for StatsBomb open data.
+
+This script downloads a sample of StatsBomb open-data matches, builds a
+possession-based Markov chain that approximates Ian Graham's possession value
+model, and produces an interactive Plotly heatmap that visualises the value of
+different actions from different pitch locations.
+
+Usage (from the repository root):
+
+    python markov_value_model.py --max-matches 20 --output value_model.html
+
+The script keeps the file structure intentionally simple so it can be dropped
+into presentations or notebooks without additional project scaffolding.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import plotly.graph_objects as go
+import requests
+
+STATS_BOMB_BASE = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
+
+# Pitch and grid settings (StatsBomb pitch: 120 x 80 coordinates)
+PITCH_LENGTH = 120.0
+PITCH_WIDTH = 80.0
+GRID_X = 6
+GRID_Y = 4
+
+
+def fetch_json(url: str) -> list:
+    """Download JSON data from StatsBomb's open-data GitHub repository."""
+
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def load_matches(competition_id: int, season_id: int) -> list:
+    """Load the list of matches for a competition/season pair."""
+
+    url = f"{STATS_BOMB_BASE}/matches/{competition_id}/{season_id}.json"
+    return fetch_json(url)
+
+
+def load_match_events(match_id: int) -> list:
+    """Fetch the events for a specific match."""
+
+    url = f"{STATS_BOMB_BASE}/events/{match_id}.json"
+    return fetch_json(url)
+
+
+def location_to_zone(location: Sequence[float]) -> Optional[int]:
+    """Convert a StatsBomb (x, y) location into a grid zone index."""
+
+    if not location or len(location) < 2:
+        return None
+
+    x, y = location[:2]
+    if x is None or y is None:
+        return None
+
+    # Clamp to pitch boundaries just in case the feed contains out-of-bounds
+    x = min(max(x, 0.0), PITCH_LENGTH - 1e-6)
+    y = min(max(y, 0.0), PITCH_WIDTH - 1e-6)
+
+    x_bin = int(x / (PITCH_LENGTH / GRID_X))
+    y_bin = int(y / (PITCH_WIDTH / GRID_Y))
+    return y_bin * GRID_X + x_bin
+
+
+def zone_to_grid(zone: int) -> Tuple[int, int]:
+    """Return the (x, y) grid coordinate for a zone index."""
+
+    x = zone % GRID_X
+    y = zone // GRID_X
+    return x, y
+
+
+def find_next_possession_event(events: List[dict], start_idx: int, possession_id: int) -> Optional[dict]:
+    """Return the next event in the same possession with a location."""
+
+    for event in events[start_idx + 1 :]:
+        if event.get("possession") != possession_id:
+            return None
+        if location_to_zone(event.get("location")) is not None:
+            return event
+        # Continue searching within the same possession for an actionable event
+    return None
+
+
+def determine_next_state(event: dict, next_event: Optional[dict]) -> Tuple[str, Optional[int]]:
+    """Determine the transition outcome for an event.
+
+    Returns a tuple of (state_type, value) where state_type is one of:
+    - "zone": possession continues in another zone.
+    - "goal": the action results in a goal for the possessing team.
+    - "turnover": the possession ends without a goal.
+    """
+
+    if "shot" in event:
+        outcome = event["shot"].get("outcome", {}).get("name")
+        if outcome == "Goal":
+            return "goal", None
+        return "turnover", None
+
+    if next_event is None:
+        return "turnover", None
+
+    next_zone = location_to_zone(next_event.get("location"))
+    if next_zone is None:
+        return "turnover", None
+
+    return "zone", next_zone
+
+
+def build_transition_counts(matches_events: Iterable[List[dict]]) -> Tuple[Dict[int, Counter], Dict[Tuple[int, str], Counter]]:
+    """Aggregate transition counts for states and actions."""
+
+    zone_counts: Dict[int, Counter] = defaultdict(Counter)
+    action_counts: Dict[Tuple[int, str], Counter] = defaultdict(Counter)
+
+    for events in matches_events:
+        for idx, event in enumerate(events):
+            zone = location_to_zone(event.get("location"))
+            if zone is None:
+                continue
+
+            action = event.get("type", {}).get("name", "Unknown")
+            possession_id = event.get("possession")
+            next_event = find_next_possession_event(events, idx, possession_id)
+            state_type, state_value = determine_next_state(event, next_event)
+
+            zone_counts[zone][state_type if state_value is None else (state_type, state_value)] += 1
+            action_counts[(zone, action)][state_type if state_value is None else (state_type, state_value)] += 1
+
+    return zone_counts, action_counts
+
+
+def counts_to_transition_matrix(zone_counts: Dict[int, Counter]) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert transition counters into matrices.
+
+    Returns:
+        P (np.ndarray): transition matrix between in-play zones.
+        goal_probs (np.ndarray): probability of scoring on the next action.
+        turnover_probs (np.ndarray): probability of ending the possession.
+    """
+
+    num_zones = GRID_X * GRID_Y
+    P = np.zeros((num_zones, num_zones))
+    goal_probs = np.zeros(num_zones)
+    turnover_probs = np.zeros(num_zones)
+
+    for zone in range(num_zones):
+        counts = zone_counts.get(zone, Counter())
+        total = sum(counts.values())
+        if total == 0:
+            continue
+
+        for outcome, count in counts.items():
+            if outcome == "goal":
+                goal_probs[zone] += count / total
+            elif outcome == "turnover":
+                turnover_probs[zone] += count / total
+            else:
+                _, next_zone = outcome
+                P[zone, next_zone] += count / total
+
+        # Normalise any rounding errors
+        row_sum = P[zone].sum() + goal_probs[zone] + turnover_probs[zone]
+        if row_sum > 0:
+            P[zone] /= row_sum
+            goal_probs[zone] /= row_sum
+            turnover_probs[zone] /= row_sum
+
+    return P, goal_probs, turnover_probs
+
+
+def solve_state_value(P: np.ndarray, goal_probs: np.ndarray, gamma: float = 1.0) -> np.ndarray:
+    """Solve the Markov chain value function.
+
+    Args:
+        P: Transition probabilities between non-terminal states.
+        goal_probs: Probability of scoring immediately from each state.
+        gamma: Discount factor. A value < 1 emphasises immediate rewards.
+    """
+
+    identity = np.eye(P.shape[0])
+    system_matrix = identity - gamma * P
+    return np.linalg.solve(system_matrix, goal_probs)
+
+
+def compute_action_values(
+    action_counts: Dict[Tuple[int, str], Counter],
+    state_values: np.ndarray,
+) -> Dict[Tuple[int, str], float]:
+    """Calculate the expected value of taking each action in each zone."""
+
+    action_values: Dict[Tuple[int, str], float] = {}
+
+    for (zone, action), counts in action_counts.items():
+        total = sum(counts.values())
+        if total == 0:
+            continue
+
+        value = 0.0
+        for outcome, count in counts.items():
+            prob = count / total
+            if outcome == "goal":
+                value += prob
+            elif outcome == "turnover":
+                continue
+            else:
+                _, next_zone = outcome
+                value += prob * state_values[next_zone]
+
+        action_values[(zone, action)] = value
+
+    return action_values
+
+
+def grid_from_values(values: Dict[int, float], default: Optional[float] = None) -> np.ndarray:
+    """Map zone-indexed values onto a 2D grid for plotting."""
+
+    grid = np.full((GRID_Y, GRID_X), np.nan)
+    for zone, val in values.items():
+        x, y = zone_to_grid(zone)
+        # Flip y-axis so the attacking goal (x = 120) appears at the top of the heatmap
+        grid[GRID_Y - 1 - y, x] = val
+
+    if default is not None:
+        grid = np.nan_to_num(grid, nan=default)
+
+    return grid
+
+
+def build_interactive_figure(
+    state_values: np.ndarray,
+    discounted_state_values: np.ndarray,
+    action_values: Dict[Tuple[int, str], float],
+) -> go.Figure:
+    """Create a Plotly figure with interactive dropdowns for different metrics."""
+
+    num_zones = GRID_X * GRID_Y
+    zone_value_map = {zone: state_values[zone] for zone in range(num_zones)}
+    discounted_map = {zone: discounted_state_values[zone] for zone in range(num_zones)}
+
+    heatmaps = []
+    labels = []
+
+    heatmaps.append(grid_from_values(zone_value_map))
+    labels.append("State Value (xG probability)")
+
+    heatmaps.append(grid_from_values(discounted_map))
+    labels.append("Discounted Value (quick chance focus)")
+
+    # Aggregate action values and advantage (RL-style improvement over average)
+    base_values = state_values.copy()
+    actions_by_name = sorted({action for _, action in action_values.keys()})
+
+    for action in actions_by_name:
+        action_map = {}
+        advantage_map = {}
+        for zone in range(num_zones):
+            key = (zone, action)
+            if key in action_values:
+                action_map[zone] = action_values[key]
+                advantage_map[zone] = action_values[key] - base_values[zone]
+
+        if action_map:
+            heatmaps.append(grid_from_values(action_map))
+            labels.append(f"Action Value: {action}")
+
+        if advantage_map:
+            heatmaps.append(grid_from_values(advantage_map))
+            labels.append(f"Action Advantage: {action}")
+
+    x_labels = [f"Zone {x + 1}" for x in range(GRID_X)]
+    y_labels = [f"Band {GRID_Y - y}" for y in range(GRID_Y)]
+
+    traces = []
+    for heatmap in heatmaps:
+        traces.append(
+            go.Heatmap(
+                z=heatmap,
+                x=x_labels,
+                y=y_labels,
+                colorscale="YlOrRd",
+                zmin=0,
+                zmax=float(np.nanmax(heatmap)) if np.isfinite(np.nanmax(heatmap)) else 1.0,
+                colorbar=dict(title="xG"),
+                visible=False,
+            )
+        )
+
+    if traces:
+        traces[0].visible = True
+
+    fig = go.Figure(data=traces)
+
+    buttons = []
+    for idx, label in enumerate(labels):
+        visibility = [False] * len(traces)
+        visibility[idx] = True
+        buttons.append(dict(label=label, method="update", args=[{"visible": visibility}, {"title": label}]))
+
+    fig.update_layout(
+        title=labels[0] if labels else "Markov Chain Value Model",
+        xaxis=dict(title="Pitch length (left to right)", side="top"),
+        yaxis=dict(title="Pitch width", autorange="reversed"),
+        updatemenus=[dict(buttons=buttons, direction="down", showactive=True)],
+        template="plotly_white",
+    )
+
+    return fig
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Markov chain value model for StatsBomb open data")
+    parser.add_argument("--competition", type=int, default=43, help="Competition ID (default: FIFA World Cup 2018)")
+    parser.add_argument("--season", type=int, default=3, help="Season ID for the chosen competition")
+    parser.add_argument("--max-matches", type=int, default=15, help="Number of matches to include (limits data size)")
+    parser.add_argument("--output", type=Path, default=Path("value_model.html"), help="Where to save the interactive plot")
+    args = parser.parse_args()
+
+    matches = load_matches(args.competition, args.season)
+    if args.max_matches:
+        matches = matches[: args.max_matches]
+
+    print(f"Downloading events for {len(matches)} matches...")
+    matches_events = []
+    for match in matches:
+        match_id = match["match_id"]
+        events = load_match_events(match_id)
+        matches_events.append(events)
+        print(f"Loaded match {match_id} with {len(events)} events")
+
+    zone_counts, action_counts = build_transition_counts(matches_events)
+    P, goal_probs, _ = counts_to_transition_matrix(zone_counts)
+
+    state_values = solve_state_value(P, goal_probs, gamma=1.0)
+    discounted_state_values = solve_state_value(P, goal_probs, gamma=0.9)
+    action_values = compute_action_values(action_counts, state_values)
+
+    fig = build_interactive_figure(state_values, discounted_state_values, action_values)
+    fig.write_html(str(args.output), include_plotlyjs="cdn")
+
+    print(f"Saved interactive visualisation to {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/markov_value_model.py
+++ b/markov_value_model.py
@@ -1,954 +1,804 @@
-"""Enhanced Markov chain value model for StatsBomb open data.
+"""Interactive Markov chain visualiser built purely from StatsBomb 360 data.
 
-This script downloads a sample of StatsBomb open-data matches, builds a
-possession-based Markov chain that approximates Ian Graham's possession value
-model, and produces a suite of visualisations:
+The script downloads StatsBomb 360 freeze frames for matches that include them
+and uses the player locations in each freeze frame to build a very transparent
+Markov decision process (MDP) style value function:
 
-* an interactive Plotly heatmap with higher-resolution grids and goal markers,
-* a static Matplotlib figure for presentations,
-* a support-aware model using StatsBomb 360 freeze frames,
-* an average ball-progression quiver plot, and
-* a shot quality heatmap by distance and angle.
+* Each freeze-framed event provides a *state* represented by a grid covering the
+  pitch. Grid cells accumulate positive weight for supporting teammates and
+  negative weight for defenders. The ball carrier adds extra positive weight so
+  the update focuses on the area of play.
+* The value function starts as zeros and is updated sequentially with temporal
+  difference learning so you can watch the grid evolve as events unfold.
+* Rewards are derived from the event outcomes (shots, assists, possession
+  changes) to keep the example intuitive.
+* An interactive Plotly animation lets you step through the match, showing the
+  updated value grid alongside the player and ball locations on a stylised pitch.
 
-Usage (from the repository root):
-
-    python markov_value_model.py --max-matches 20
-
-The script keeps the file structure intentionally simple so it can be dropped
-into presentations or notebooks without additional project scaffolding.
+The workflow stays in a single file and requires only ``numpy``, ``plotly`` and
+``requests`` so it is easy to reuse for presentations or workshops.
 """
 
 from __future__ import annotations
 
 import argparse
-from collections import Counter, defaultdict
+import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
-try:
-    import matplotlib.pyplot as plt
-except ImportError:  # pragma: no cover - optional dependency
-    plt = None  # type: ignore[assignment]
-
-if TYPE_CHECKING:  # pragma: no cover
-    from matplotlib.axes import Axes
 import numpy as np
 import plotly.graph_objects as go
 import requests
-from requests.exceptions import HTTPError
+from requests import Response
 
 STATS_BOMB_BASE = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
+CACHE_DIR = Path("statsbomb_cache")
 
-# Pitch and grid settings (StatsBomb pitch: 120 x 80 coordinates)
 PITCH_LENGTH = 120.0
 PITCH_WIDTH = 80.0
-GRID_X = 12
-GRID_Y = 8
-CELL_LENGTH = PITCH_LENGTH / GRID_X
-CELL_WIDTH = PITCH_WIDTH / GRID_Y
 
 
-def fetch_json(url: str) -> list:
-    """Download JSON data from StatsBomb's open-data GitHub repository."""
+@dataclass
+class MatchSummary:
+    """Lightweight container for matches that ship with StatsBomb 360 data."""
 
-    response = requests.get(url, timeout=30)
+    competition_id: int
+    competition_name: str
+    season_id: int
+    season_name: str
+    match_id: int
+    home_team: str
+    away_team: str
+    match_date: str
+    freeze_frame_events: int
+
+
+def fetch_statsbomb(path: str, allow_missing: bool = False) -> Optional[Iterable]:
+    """Download and cache a JSON document from the StatsBomb open-data repo."""
+
+    cache_path = CACHE_DIR / path
+    if cache_path.exists():
+        with cache_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    url = f"{STATS_BOMB_BASE}/{path}"
+    response: Response = requests.get(url, timeout=30)
+    if response.status_code == 404:
+        if allow_missing:
+            return None
+        response.raise_for_status()
     response.raise_for_status()
-    return response.json()
+
+    data = response.json()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with cache_path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle)
+    return data
 
 
-def load_matches(competition_id: int, season_id: int) -> list:
-    """Load the list of matches for a competition/season pair."""
+def load_competitions() -> List[dict]:
+    """Return all competitions from the open-data set."""
 
-    url = f"{STATS_BOMB_BASE}/matches/{competition_id}/{season_id}.json"
-    return fetch_json(url)
-
-
-def load_match_events(match_id: int) -> list:
-    """Fetch the events for a specific match."""
-
-    url = f"{STATS_BOMB_BASE}/events/{match_id}.json"
-    return fetch_json(url)
+    competitions = fetch_statsbomb("competitions.json")
+    if competitions is None:
+        raise RuntimeError("Unable to download competitions list from StatsBomb.")
+    return list(competitions)
 
 
-def load_three_sixty(match_id: int) -> Dict[str, list]:
-    """Fetch StatsBomb 360 freeze frames for a match (if available)."""
+def load_matches(competition_id: int, season_id: int) -> List[dict]:
+    """Return the matches for a competition/season pair."""
 
-    url = f"{STATS_BOMB_BASE}/three-sixty/{match_id}.json"
-    try:
-        frames = fetch_json(url)
-    except HTTPError:
+    matches = fetch_statsbomb(f"matches/{competition_id}/{season_id}.json")
+    return list(matches or [])
+
+
+def load_events(match_id: int) -> List[dict]:
+    """Return the ordered StatsBomb events for a match."""
+
+    events = fetch_statsbomb(f"events/{match_id}.json")
+    return list(events or [])
+
+
+def load_freeze_frames(match_id: int) -> Dict[str, List[dict]]:
+    """Map event UUIDs to freeze-frame player locations for a match."""
+
+    frames = fetch_statsbomb(f"three-sixty/{match_id}.json", allow_missing=True)
+    if not frames:
         return {}
 
-    frame_map = {}
-    for frame in frames:
-        event_uuid = frame.get("event_uuid")
-        if event_uuid:
-            frame_map[event_uuid] = frame.get("freeze_frame", [])
-    return frame_map
+    mapping: Dict[str, List[dict]] = {}
+    for entry in frames:
+        event_uuid = entry.get("event_uuid")
+        if not event_uuid:
+            continue
+        mapping[event_uuid] = entry.get("freeze_frame", [])
+    return mapping
 
 
-def location_to_zone(location: Sequence[float]) -> Optional[int]:
-    """Convert a StatsBomb (x, y) location into a grid zone index."""
+def discover_three_sixty_matches(
+    *,
+    competition_filter: Optional[int] = None,
+    season_filter: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> List[MatchSummary]:
+    """Return matches that include StatsBomb 360 freeze frames."""
+
+    summaries: List[MatchSummary] = []
+    for competition in load_competitions():
+        comp_id = int(competition["competition_id"])
+        season_id = int(competition["season_id"])
+        if competition_filter is not None and comp_id != competition_filter:
+            continue
+        if season_filter is not None and season_id != season_filter:
+            continue
+
+        for match in load_matches(comp_id, season_id):
+            match_id = int(match["match_id"])
+            freeze_frames = fetch_statsbomb(
+                f"three-sixty/{match_id}.json", allow_missing=True
+            )
+            if not freeze_frames:
+                continue
+
+            freeze_event_count = sum(
+                1 for frame in freeze_frames if frame.get("freeze_frame")
+            )
+            summaries.append(
+                MatchSummary(
+                    competition_id=comp_id,
+                    competition_name=competition.get("competition_name", ""),
+                    season_id=season_id,
+                    season_name=competition.get("season_name", ""),
+                    match_id=match_id,
+                    home_team=match.get("home_team", {}).get("home_team_name", ""),
+                    away_team=match.get("away_team", {}).get("away_team_name", ""),
+                    match_date=match.get("match_date", ""),
+                    freeze_frame_events=freeze_event_count,
+                )
+            )
+            if limit and len(summaries) >= limit:
+                return summaries
+    return summaries
+
+
+def coordinate_to_cell(
+    location: Sequence[float], grid_x: int, grid_y: int
+) -> Optional[Tuple[int, int]]:
+    """Convert a StatsBomb (x, y) location to a grid index (row, column)."""
 
     if not location or len(location) < 2:
         return None
-
     x, y = location[:2]
     if x is None or y is None:
         return None
 
-    # Clamp to pitch boundaries just in case the feed contains out-of-bounds
-    x = min(max(x, 0.0), PITCH_LENGTH - 1e-6)
-    y = min(max(y, 0.0), PITCH_WIDTH - 1e-6)
+    x = min(max(float(x), 0.0), PITCH_LENGTH - 1e-6)
+    y = min(max(float(y), 0.0), PITCH_WIDTH - 1e-6)
 
-    x_bin = int(x / (PITCH_LENGTH / GRID_X))
-    y_bin = int(y / (PITCH_WIDTH / GRID_Y))
-    return y_bin * GRID_X + x_bin
-
-
-def zone_to_grid(zone: int) -> Tuple[int, int]:
-    """Return the (x, y) grid coordinate for a zone index."""
-
-    x = zone % GRID_X
-    y = zone // GRID_X
-    return x, y
+    x_idx = int(x / (PITCH_LENGTH / grid_x))
+    y_idx = int(y / (PITCH_WIDTH / grid_y))
+    return y_idx, x_idx
 
 
-def find_next_possession_event(events: List[dict], start_idx: int, possession_id: int) -> Optional[dict]:
-    """Return the next event in the same possession with a location."""
+def build_context_grid(
+    freeze_frame: List[dict],
+    ball_location: Optional[Sequence[float]],
+    grid_x: int,
+    grid_y: int,
+) -> np.ndarray:
+    """Create a grid weighting teammates positively and defenders negatively."""
 
-    for event in events[start_idx + 1 :]:
-        if event.get("possession") != possession_id:
-            return None
-        if location_to_zone(event.get("location")) is not None:
-            return event
-        # Continue searching within the same possession for an actionable event
-    return None
-
-
-def determine_next_state(event: dict, next_event: Optional[dict]) -> Tuple[str, Optional[int]]:
-    """Determine the transition outcome for an event.
-
-    Returns a tuple of (state_type, value) where state_type is one of:
-    - "zone": possession continues in another zone.
-    - "goal": the action results in a goal for the possessing team.
-    - "turnover": the possession ends without a goal.
-    """
-
-    if "shot" in event:
-        outcome = event["shot"].get("outcome", {}).get("name")
-        if outcome == "Goal":
-            return "goal", None
-        return "turnover", None
-
-    if next_event is None:
-        return "turnover", None
-
-    next_zone = location_to_zone(next_event.get("location"))
-    if next_zone is None:
-        return "turnover", None
-
-    return "zone", next_zone
-
-
-def build_transition_counts(matches_events: Iterable[List[dict]]) -> Tuple[Dict[int, Counter], Dict[Tuple[int, str], Counter]]:
-    """Aggregate transition counts for states and actions."""
-
-    zone_counts: Dict[int, Counter] = defaultdict(Counter)
-    action_counts: Dict[Tuple[int, str], Counter] = defaultdict(Counter)
-
-    for events in matches_events:
-        for idx, event in enumerate(events):
-            zone = location_to_zone(event.get("location"))
-            if zone is None:
-                continue
-
-            action = event.get("type", {}).get("name", "Unknown")
-            possession_id = event.get("possession")
-            next_event = find_next_possession_event(events, idx, possession_id)
-            state_type, state_value = determine_next_state(event, next_event)
-
-            zone_counts[zone][state_type if state_value is None else (state_type, state_value)] += 1
-            action_counts[(zone, action)][state_type if state_value is None else (state_type, state_value)] += 1
-
-    return zone_counts, action_counts
-
-
-def counts_to_transition_matrix(zone_counts: Dict[int, Counter]) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Convert transition counters into matrices.
-
-    Returns:
-        P (np.ndarray): transition matrix between in-play zones.
-        goal_probs (np.ndarray): probability of scoring on the next action.
-        turnover_probs (np.ndarray): probability of ending the possession.
-    """
-
-    num_zones = GRID_X * GRID_Y
-    P = np.zeros((num_zones, num_zones))
-    goal_probs = np.zeros(num_zones)
-    turnover_probs = np.zeros(num_zones)
-
-    for zone in range(num_zones):
-        counts = zone_counts.get(zone, Counter())
-        total = sum(counts.values())
-        if total == 0:
+    grid = np.zeros((grid_y, grid_x), dtype=float)
+    for player in freeze_frame:
+        player_location = player.get("location")
+        cell = coordinate_to_cell(player_location, grid_x, grid_y)
+        if cell is None:
             continue
+        row, col = cell
+        weight = 1.0 if player.get("teammate") else -1.0
+        # Goalkeepers are influential, give them extra magnitude.
+        if player.get("keeper"):
+            weight *= 1.5
+        grid[row, col] += weight
 
-        for outcome, count in counts.items():
-            if outcome == "goal":
-                goal_probs[zone] += count / total
-            elif outcome == "turnover":
-                turnover_probs[zone] += count / total
-            else:
-                _, next_zone = outcome
-                P[zone, next_zone] += count / total
+    ball_cell = (
+        coordinate_to_cell(ball_location, grid_x, grid_y)
+        if ball_location is not None
+        else None
+    )
+    if ball_cell is not None:
+        row, col = ball_cell
+        grid[row, col] += 2.0
 
-        # Normalise any rounding errors
-        row_sum = P[zone].sum() + goal_probs[zone] + turnover_probs[zone]
-        if row_sum > 0:
-            P[zone] /= row_sum
-            goal_probs[zone] /= row_sum
-            turnover_probs[zone] /= row_sum
-
-    return P, goal_probs, turnover_probs
-
-
-def solve_state_value(P: np.ndarray, goal_probs: np.ndarray, gamma: float = 1.0) -> np.ndarray:
-    """Solve the Markov chain value function.
-
-    Args:
-        P: Transition probabilities between non-terminal states.
-        goal_probs: Probability of scoring immediately from each state.
-        gamma: Discount factor. A value < 1 emphasises immediate rewards.
-    """
-
-    identity = np.eye(P.shape[0])
-    system_matrix = identity - gamma * P
-    return np.linalg.solve(system_matrix, goal_probs)
-
-
-def compute_action_values(
-    action_counts: Dict[Tuple[int, str], Counter],
-    state_values: np.ndarray,
-) -> Dict[Tuple[int, str], float]:
-    """Calculate the expected value of taking each action in each zone."""
-
-    action_values: Dict[Tuple[int, str], float] = {}
-
-    for (zone, action), counts in action_counts.items():
-        total = sum(counts.values())
-        if total == 0:
-            continue
-
-        value = 0.0
-        for outcome, count in counts.items():
-            prob = count / total
-            if outcome == "goal":
-                value += prob
-            elif outcome == "turnover":
-                continue
-            else:
-                _, next_zone = outcome
-                value += prob * state_values[next_zone]
-
-        action_values[(zone, action)] = value
-
-    return action_values
-
-
-def grid_from_values(values: Dict[int, float], default: Optional[float] = None) -> np.ndarray:
-    """Map zone-indexed values onto a 2D grid for plotting."""
-
-    grid = np.full((GRID_Y, GRID_X), np.nan)
-    for zone, val in values.items():
-        x, y = zone_to_grid(zone)
-        # Flip y-axis so the attacking goal (x = 120) appears at the top of the heatmap
-        grid[GRID_Y - 1 - y, x] = val
-
-    if default is not None:
-        grid = np.nan_to_num(grid, nan=default)
-
+    norm = float(np.sum(np.abs(grid)))
+    if norm > 0.0:
+        grid /= norm
     return grid
 
 
-def grid_centres() -> Tuple[np.ndarray, np.ndarray]:
-    """Return the x/y coordinates for the centre of each zone cell."""
+def describe_event(event: dict) -> str:
+    """Return a human readable summary for an event."""
 
-    x_centers = np.linspace(CELL_LENGTH / 2, PITCH_LENGTH - CELL_LENGTH / 2, GRID_X)
-    y_centers = np.linspace(PITCH_WIDTH - CELL_WIDTH / 2, CELL_WIDTH / 2, GRID_Y)
-    return x_centers, y_centers
+    minute = int(event.get("minute", 0))
+    second = int(event.get("second", 0))
+    player_name = event.get("player", {}).get("name") or "Unknown player"
+    event_type = event.get("type", {}).get("name") or "Action"
 
+    extra = ""
+    if event_type == "Shot":
+        shot = event.get("shot", {})
+        outcome = shot.get("outcome", {}).get("name")
+        if outcome:
+            extra = f" ({outcome})"
+    elif event_type == "Pass":
+        passed = event.get("pass", {})
+        if passed.get("goal_assist"):
+            extra = " (assist)"
+        elif passed.get("shot_assist"):
+            extra = " (shot assist)"
 
-def create_pitch_shapes() -> List[dict]:
-    """Return Plotly shape definitions for a simple pitch with goals."""
-
-    penalty_width = 44.0
-    six_yard_width = 20.0
-    goal_width = 8.0
-    penalty_depth = 18.0
-    six_yard_depth = 6.0
-    goal_depth = 2.0
-    center_y = PITCH_WIDTH / 2
-
-    shapes: List[dict] = [
-        dict(type="rect", x0=0, y0=0, x1=PITCH_LENGTH, y1=PITCH_WIDTH, line=dict(color="black", width=2)),
-        dict(type="line", x0=PITCH_LENGTH / 2, y0=0, x1=PITCH_LENGTH / 2, y1=PITCH_WIDTH, line=dict(color="black", width=1)),
-        dict(
-            type="circle",
-            x0=PITCH_LENGTH / 2 - 10,
-            y0=center_y - 10,
-            x1=PITCH_LENGTH / 2 + 10,
-            y1=center_y + 10,
-            line=dict(color="black", width=1),
-        ),
-    ]
-
-    for side in (0, PITCH_LENGTH - penalty_depth):
-        direction = 1 if side == 0 else -1
-        x0 = side
-        x1 = side + direction * penalty_depth
-        shapes.append(
-            dict(
-                type="rect",
-                x0=min(x0, x1),
-                x1=max(x0, x1),
-                y0=center_y - penalty_width / 2,
-                y1=center_y + penalty_width / 2,
-                line=dict(color="black", width=1),
-            )
-        )
-        x0 = side
-        x1 = side + direction * six_yard_depth
-        shapes.append(
-            dict(
-                type="rect",
-                x0=min(x0, x1),
-                x1=max(x0, x1),
-                y0=center_y - six_yard_width / 2,
-                y1=center_y + six_yard_width / 2,
-                line=dict(color="black", width=1),
-            )
-        )
-        goal_x0 = side - direction * goal_depth
-        goal_x1 = side
-        shapes.append(
-            dict(
-                type="rect",
-                x0=min(goal_x0, goal_x1),
-                x1=max(goal_x0, goal_x1),
-                y0=center_y - goal_width / 2,
-                y1=center_y + goal_width / 2,
-                line=dict(color="black", width=2),
-                fillcolor="rgba(200,200,200,0.3)",
-            )
-        )
-
-    return shapes
+    return f"{minute:02d}:{second:02d} - {player_name} {event_type}{extra}"
 
 
-def build_interactive_figure(
-    state_values: np.ndarray,
-    discounted_state_values: np.ndarray,
-    action_values: Dict[Tuple[int, str], float],
-) -> go.Figure:
-    """Create a Plotly figure with interactive dropdowns for different metrics."""
+def extract_player_positions(freeze_frame: List[dict]) -> Tuple[List[dict], List[dict]]:
+    """Return teammate and opponent positions for plotting."""
 
-    num_zones = GRID_X * GRID_Y
-    zone_value_map = {zone: state_values[zone] for zone in range(num_zones)}
-    discounted_map = {zone: discounted_state_values[zone] for zone in range(num_zones)}
-
-    heatmaps: List[Dict[str, object]] = []
-
-    def append_heatmap(matrix: np.ndarray, label: str, *, diverging: bool = False, colorbar: str = "xG") -> None:
-        finite = matrix[np.isfinite(matrix)]
-        if finite.size == 0:
-            zmin, zmax = (0.0, 1.0)
+    teammates: List[dict] = []
+    opponents: List[dict] = []
+    for player in freeze_frame:
+        location = player.get("location")
+        if not location or len(location) < 2:
+            continue
+        x, y = float(location[0]), float(location[1])
+        point = {
+            "x": x,
+            "y": y,
+            "name": player.get("player", {}).get("name", ""),
+        }
+        if player.get("teammate"):
+            teammates.append(point)
         else:
-            zmin, zmax = float(finite.min()), float(finite.max())
-        colorscale = "YlOrRd"
-        if diverging:
-            bound = max(abs(zmin), abs(zmax)) or 1.0
-            zmin, zmax = -bound, bound
-            colorscale = "RdBu"
-        elif zmin == zmax:
-            zmax = zmin + 1e-6
+            opponents.append(point)
+    return teammates, opponents
 
-        heatmaps.append(
+
+def compute_reward(current_event: dict, next_event: Optional[dict]) -> float:
+    """Simple reward signal based on event outcomes and possession changes."""
+
+    reward = 0.0
+    event_type = current_event.get("type", {}).get("name")
+
+    if event_type == "Shot":
+        shot = current_event.get("shot", {})
+        outcome = shot.get("outcome", {}).get("name")
+        if outcome == "Goal":
+            reward = 1.0
+        else:
+            reward = float(shot.get("statsbomb_xg") or 0.0)
+            if outcome in {"Saved", "Saved To Post"}:
+                reward *= 0.5
+            elif outcome in {"Off T", "Post"}:
+                reward *= 0.2
+    elif event_type == "Pass":
+        passed = current_event.get("pass", {})
+        if passed.get("goal_assist"):
+            reward = 0.6
+        elif passed.get("shot_assist"):
+            reward = 0.3
+        elif passed.get("switch"):
+            reward = 0.1
+    elif event_type in {"Ball Receipt", "Carry"}:
+        reward = 0.05
+
+    if next_event is not None:
+        current_team = current_event.get("possession_team", {}).get("id")
+        next_team = next_event.get("possession_team", {}).get("id")
+        if current_team and next_team and current_team != next_team:
+            reward -= 0.1
+    return reward
+
+
+def build_value_snapshots(
+    events: List[dict],
+    freeze_frames: Dict[str, List[dict]],
+    grid_x: int,
+    grid_y: int,
+    gamma: float,
+    alpha: float,
+) -> List[dict]:
+    """Generate sequential value-grid snapshots for freeze-framed events."""
+
+    timeline: List[dict] = []
+    for event in events:
+        event_uuid = event.get("id")
+        if not event_uuid:
+            continue
+        freeze_frame = freeze_frames.get(event_uuid)
+        if not freeze_frame:
+            continue
+
+        context_grid = build_context_grid(
+            freeze_frame, event.get("location"), grid_x, grid_y
+        )
+        teammates, opponents = extract_player_positions(freeze_frame)
+        ball_location = event.get("location")
+        ball_point = {
+            "x": float(ball_location[0]) if ball_location else None,
+            "y": float(ball_location[1]) if ball_location else None,
+        }
+
+        timeline.append(
             {
-                "matrix": matrix,
-                "label": label,
-                "zmin": zmin,
-                "zmax": zmax,
-                "colorscale": colorscale,
-                "colorbar": colorbar,
+                "event": event,
+                "context": context_grid,
+                "description": describe_event(event),
+                "teammates": teammates,
+                "opponents": opponents,
+                "ball": ball_point,
             }
         )
 
-    append_heatmap(grid_from_values(zone_value_map), "State Value (xG probability)")
-    append_heatmap(grid_from_values(discounted_map), "Discounted Value (quick chance focus)")
+    value_grid = np.zeros((grid_y, grid_x), dtype=float)
+    snapshots: List[dict] = []
 
-    base_values = state_values.copy()
-    actions_by_name = sorted({action for _, action in action_values.keys()})
-    for action in actions_by_name:
-        action_map = {}
-        advantage_map = {}
-        for zone in range(num_zones):
-            key = (zone, action)
-            if key in action_values:
-                action_map[zone] = action_values[key]
-                advantage_map[zone] = action_values[key] - base_values[zone]
+    for idx, record in enumerate(timeline):
+        next_record = timeline[idx + 1] if idx + 1 < len(timeline) else None
+        reward = compute_reward(record["event"], next_record["event"] if next_record else None)
 
-        if action_map:
-            append_heatmap(grid_from_values(action_map), f"Action Value: {action}")
-        if advantage_map:
-            append_heatmap(
-                grid_from_values(advantage_map),
-                f"Action Advantage: {action}",
-                diverging=True,
-                colorbar="Advantage",
-            )
+        context = record["context"]
+        next_context = next_record["context"] if next_record else None
 
-    x_centers, y_centers = grid_centres()
+        state_value = float(np.sum(value_grid * context))
+        next_value = float(np.sum(value_grid * next_context)) if next_context is not None else 0.0
+        td_error = reward + gamma * next_value - state_value
 
-    traces = []
-    for spec in heatmaps:
-        traces.append(
-            go.Heatmap(
-                z=spec["matrix"],
-                x=x_centers,
-                y=y_centers,
-                colorscale=spec["colorscale"],
-                zmin=spec["zmin"],
-                zmax=spec["zmax"],
-                colorbar=dict(title=spec["colorbar"]),
-                hovertemplate="x: %{x:.1f}<br>y: %{y:.1f}<br>value: %{z:.3f}<extra></extra>",
-                visible=False,
-            )
+        value_grid = value_grid + alpha * td_error * context
+
+        snapshots.append(
+            {
+                "value_grid": value_grid.copy(),
+                "teammates": record["teammates"],
+                "opponents": record["opponents"],
+                "ball": record["ball"],
+                "description": record["description"],
+                "reward": reward,
+                "state_value": state_value,
+                "td_error": td_error,
+            }
         )
-
-    if traces:
-        traces[0].visible = True
-
-    fig = go.Figure(data=traces)
-
-    buttons = []
-    for idx, spec in enumerate(heatmaps):
-        visibility = [False] * len(traces)
-        visibility[idx] = True
-        buttons.append(
-            dict(label=spec["label"], method="update", args=[{"visible": visibility}, {"title": spec["label"]}])
-        )
-
-    fig.update_layout(
-        title=heatmaps[0]["label"] if heatmaps else "Markov Chain Value Model",
-        xaxis=dict(title="Pitch length (yards)", range=[0, PITCH_LENGTH], constrain="domain"),
-        yaxis=dict(title="Pitch width (yards)", range=[PITCH_WIDTH, 0], scaleanchor="x", scaleratio=1),
-        updatemenus=[dict(buttons=buttons, direction="down", showactive=True, x=1.05, xanchor="left")],
-        template="plotly_white",
-        shapes=create_pitch_shapes(),
-        width=950,
-        height=600,
-    )
-
-    return fig
-
-
-def draw_pitch(ax: "Axes") -> None:
-    """Render a simple football pitch with goals onto a Matplotlib axis."""
-
-    ax.set_xlim(0, PITCH_LENGTH)
-    ax.set_ylim(0, PITCH_WIDTH)
-    ax.set_aspect("equal")
-    ax.axis("off")
-
-    # Outer lines and halfway line
-    ax.plot([0, PITCH_LENGTH, PITCH_LENGTH, 0, 0], [0, 0, PITCH_WIDTH, PITCH_WIDTH, 0], color="black", linewidth=1.5)
-    ax.plot([PITCH_LENGTH / 2, PITCH_LENGTH / 2], [0, PITCH_WIDTH], color="black", linewidth=1)
-
-    center_circle = plt.Circle((PITCH_LENGTH / 2, PITCH_WIDTH / 2), 10, fill=False, color="black", linewidth=1)
-    ax.add_patch(center_circle)
-
-    penalty_width = 44.0
-    penalty_depth = 18.0
-    six_width = 20.0
-    six_depth = 6.0
-    goal_width = 8.0
-    goal_depth = 2.0
-    center_y = PITCH_WIDTH / 2
-
-    for side in (0, PITCH_LENGTH):
-        direction = 1 if side == 0 else -1
-        penalty = plt.Rectangle(
-            (side - (1 - direction) * penalty_depth, center_y - penalty_width / 2),
-            penalty_depth * direction,
-            penalty_width,
-            fill=False,
-            color="black",
-            linewidth=1,
-        )
-        six = plt.Rectangle(
-            (side - (1 - direction) * six_depth, center_y - six_width / 2),
-            six_depth * direction,
-            six_width,
-            fill=False,
-            color="black",
-            linewidth=1,
-        )
-        goal = plt.Rectangle(
-            (side - (1 - direction) * goal_depth, center_y - goal_width / 2),
-            goal_depth * direction,
-            goal_width,
-            fill=True,
-            facecolor="lightgrey",
-            edgecolor="black",
-            linewidth=1,
-            alpha=0.4,
-        )
-        ax.add_patch(penalty)
-        ax.add_patch(six)
-        ax.add_patch(goal)
-
-
-def render_static_heatmap(ax: "Axes", matrix: np.ndarray, title: str, *, cmap: str = "YlOrRd", diverging: bool = False) -> None:
-    """Render a heatmap atop the pitch background."""
-
-    draw_pitch(ax)
-    finite = matrix[np.isfinite(matrix)]
-    if finite.size == 0:
-        vmin, vmax = (0.0, 1.0)
-    else:
-        vmin, vmax = float(finite.min()), float(finite.max())
-
-    if diverging:
-        bound = max(abs(vmin), abs(vmax)) or 1.0
-        vmin, vmax = -bound, bound
-        cmap = "RdBu_r"
-    elif vmin == vmax:
-        vmax = vmin + 1e-6
-
-    ax.imshow(
-        np.ma.masked_invalid(matrix),
-        extent=[0, PITCH_LENGTH, 0, PITCH_WIDTH],
-        origin="upper",
-        cmap=cmap,
-        vmin=vmin,
-        vmax=vmax,
-        alpha=0.85,
-    )
-    ax.set_title(title)
-
-
-def create_static_value_figure(
-    state_values: np.ndarray,
-    discounted_state_values: np.ndarray,
-    action_values: Dict[Tuple[int, str], float],
-    output: Path,
-) -> None:
-    """Save a Matplotlib figure highlighting key value surfaces."""
-
-    num_zones = GRID_X * GRID_Y
-    base_map = {zone: state_values[zone] for zone in range(num_zones)}
-    discounted_map = {zone: discounted_state_values[zone] for zone in range(num_zones)}
-
-    # Choose the two most common actions by coverage
-    action_coverage = Counter()
-    for (zone, action), value in action_values.items():
-        if value:
-            action_coverage[action] += 1
-
-    most_common = [action for action, _ in action_coverage.most_common(2)]
-    action_grids = []
-    for action in most_common:
-        action_map = {zone: value for (zone, name), value in action_values.items() if name == action}
-        action_grids.append((action, grid_from_values(action_map)))
-
-    if plt is None:
-        raise RuntimeError("Matplotlib is required for static output")
-
-    fig, axes = plt.subplots(1, 2 + len(action_grids), figsize=(5 * (2 + len(action_grids)), 6))
-    if not isinstance(axes, np.ndarray):
-        axes = np.array([axes])
-
-    render_static_heatmap(axes[0], grid_from_values(base_map), "State value")
-    render_static_heatmap(
-        axes[1],
-        grid_from_values(discounted_map),
-        "Discounted value",
-    )
-
-    for idx, (action, matrix) in enumerate(action_grids, start=2):
-        render_static_heatmap(axes[idx], matrix, f"Action value: {action}")
-
-    fig.tight_layout()
-    fig.savefig(output, dpi=200)
-    plt.close(fig)
-
-
-def possession_goal_outcome(events: List[dict], start_idx: int, possession_id: int, team_id: int) -> bool:
-    """Return True if the possession results in a goal for the given team."""
-
-    for event in events[start_idx:]:
-        if event.get("possession") != possession_id:
-            break
-        if event.get("team", {}).get("id") != team_id:
-            continue
-        shot = event.get("shot")
-        if shot and shot.get("outcome", {}).get("name") == "Goal":
-            return True
-    return False
-
-
-def freeze_frame_support_label(freeze_frame: List[dict], location: Sequence[float]) -> str:
-    """Encode supporting player context into a categorical label."""
-
-    if not location or len(location) < 2:
-        return "unknown"
-
-    teammates_near = 0
-    opponents_near = 0
-    teammates_ahead = 0
-
-    for frame in freeze_frame:
-        point = frame.get("location")
-        if not point or len(point) < 2:
-            continue
-        dx = point[0] - location[0]
-        dy = point[1] - location[1]
-        distance = float(np.hypot(dx, dy))
-        if frame.get("teammate"):
-            if distance <= 15:
-                teammates_near += 1
-            if dx > 0:
-                teammates_ahead += 1
-        else:
-            if distance <= 10:
-                opponents_near += 1
-
-    if teammates_near == 0:
-        support = "isolated"
-    elif teammates_near <= 2:
-        support = "supported"
-    else:
-        support = "overload"
-
-    if opponents_near == 0:
-        pressure = "free"
-    elif opponents_near == 1:
-        pressure = "pressure"
-    else:
-        pressure = "crowded"
-
-    ahead = "no_lane" if teammates_ahead == 0 else "lane"
-    return f"{support}/{pressure}/{ahead}"
-
-
-def compute_support_state_values(
-    matches_events: Iterable[Tuple[List[dict], Dict[str, List[dict]]]]
-) -> Dict[str, Dict[int, float]]:
-    """Estimate scoring probability conditioned on support context states."""
-
-    totals: Dict[Tuple[str, int], Counter] = defaultdict(Counter)
-
-    for events, frame_map in matches_events:
-        event_index = {event.get("id"): idx for idx, event in enumerate(events)}
-        for event_id, freeze_frame in frame_map.items():
-            idx = event_index.get(event_id)
-            if idx is None:
-                continue
-
-            event = events[idx]
-            zone = location_to_zone(event.get("location"))
-            if zone is None:
-                continue
-
-            team = event.get("team", {}).get("id")
-            possession_id = event.get("possession")
-            if team is None or possession_id is None:
-                continue
-
-            label = freeze_frame_support_label(freeze_frame, event.get("location", []))
-            goal = possession_goal_outcome(events, idx, possession_id, team)
-            totals[(label, zone)]["count"] += 1
-            if goal:
-                totals[(label, zone)]["goals"] += 1
-
-    support_maps: Dict[str, Dict[int, float]] = defaultdict(dict)
-    for (label, zone), counts in totals.items():
-        count = counts["count"]
-        goals = counts["goals"]
-        if count > 0:
-            support_maps[label][zone] = goals / count
-
-    return dict(support_maps)
-
-
-def build_support_figure(support_maps: Dict[str, Dict[int, float]]) -> go.Figure:
-    """Create a dropdown heatmap for the support-aware state values."""
-
-    x_centers, y_centers = grid_centres()
-    heatmaps = []
-    for label, zone_map in sorted(support_maps.items(), key=lambda item: item[0]):
-        matrix = grid_from_values(zone_map, default=np.nan)
-        finite = matrix[np.isfinite(matrix)]
-        if finite.size == 0:
-            continue
-        heatmaps.append((label, matrix, float(finite.min()), float(finite.max())))
-
-    traces = []
-    for label, matrix, vmin, vmax in heatmaps:
-        traces.append(
-            go.Heatmap(
-                z=matrix,
-                x=x_centers,
-                y=y_centers,
-                colorscale="Viridis",
-                zmin=vmin,
-                zmax=vmax,
-                colorbar=dict(title="xG"),
-                hovertemplate="x: %{x:.1f}<br>y: %{y:.1f}<br>value: %{z:.3f}<extra></extra>",
-                visible=False,
-            )
-        )
-
-    if traces:
-        traces[0].visible = True
-
-    buttons = []
-    for idx, (label, _, _, _) in enumerate(heatmaps):
-        visibility = [False] * len(traces)
-        visibility[idx] = True
-        buttons.append(dict(label=label, method="update", args=[{"visible": visibility}, {"title": label}]))
-
-    fig = go.Figure(data=traces)
-    fig.update_layout(
-        title=heatmaps[0][0] if heatmaps else "Support context value",
-        xaxis=dict(title="Pitch length (yards)", range=[0, PITCH_LENGTH], constrain="domain"),
-        yaxis=dict(title="Pitch width (yards)", range=[PITCH_WIDTH, 0], scaleanchor="x", scaleratio=1),
-        updatemenus=[dict(buttons=buttons, direction="down", showactive=True, x=1.05, xanchor="left")],
-        template="plotly_white",
-        shapes=create_pitch_shapes(),
-        width=950,
-        height=600,
-    )
-    return fig
-
-
-def compute_ball_progression_vectors(matches_events: Iterable[List[dict]]) -> Dict[int, Tuple[float, float, int]]:
-    """Compute average ball movement vectors (dx, dy, count) from each zone."""
-
-    vectors: Dict[int, List[Tuple[float, float]]] = defaultdict(list)
-
-    for events in matches_events:
-        for event in events:
-            zone = location_to_zone(event.get("location"))
-            if zone is None:
-                continue
-
-            end_location: Optional[Sequence[float]] = None
-            if "pass" in event:
-                end_location = event["pass"].get("end_location")
-            elif "carry" in event:
-                end_location = event["carry"].get("end_location")
-
-            if end_location and len(end_location) >= 2:
-                dx = end_location[0] - event["location"][0]
-                dy = end_location[1] - event["location"][1]
-                vectors[zone].append((dx, dy))
-
-    aggregated: Dict[int, Tuple[float, float, int]] = {}
-    for zone, displacements in vectors.items():
-        if displacements:
-            dxs, dys = zip(*displacements)
-            aggregated[zone] = (float(np.mean(dxs)), float(np.mean(dys)), len(displacements))
-
-    return aggregated
-
-
-def create_progression_plot(vectors: Dict[int, Tuple[float, float, int]], output: Path) -> None:
-    """Render a quiver plot showing average ball progression from each zone."""
-
-    if plt is None:
-        raise RuntimeError("Matplotlib is required for the progression plot")
-
-    fig, ax = plt.subplots(figsize=(10, 6))
-    draw_pitch(ax)
-
-    x_centers, y_centers = grid_centres()
-    X, Y = np.meshgrid(x_centers, y_centers)
-    U = np.zeros_like(X)
-    V = np.zeros_like(Y)
-    for zone, (dx, dy, count) in vectors.items():
-        x_idx, y_idx = zone_to_grid(zone)
-        row = GRID_Y - 1 - y_idx
-        col = x_idx
-        U[row, col] = dx
-        V[row, col] = -dy  # invert y-axis for plotting
-
-    magnitude = np.hypot(U, V)
-    max_mag = np.nanmax(magnitude) if np.isfinite(np.nanmax(magnitude)) else 1.0
-    scale = max_mag if max_mag else 1.0
-
-    quiver = ax.quiver(X, Y, U, V, magnitude, angles="xy", scale_units="xy", scale=1.5 * scale, cmap="plasma")
-    cbar = fig.colorbar(quiver, ax=ax)
-    cbar.set_label("Average movement (yards)")
-    ax.set_title("Average ball progression for passes and carries")
-    fig.tight_layout()
-    fig.savefig(output, dpi=200)
-    plt.close(fig)
-
-
-def compute_shot_quality(events: Iterable[List[dict]]) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Compute goal probability by shot distance and angle bins."""
-
-    distances = []
-    angles = []
-    outcomes = []
-
-    goal_center = np.array([PITCH_LENGTH, PITCH_WIDTH / 2])
-
-    for match_events in events:
-        for event in match_events:
-            shot = event.get("shot")
-            if not shot:
-                continue
-            location = event.get("location")
-            if not location or len(location) < 2:
-                continue
-            point = np.array(location[:2])
-            vector = goal_center - point
-            distance = float(np.hypot(vector[0], vector[1]))
-            angle = float(np.degrees(np.arctan2(abs(vector[1]), vector[0])))
-            outcome = 1.0 if shot.get("outcome", {}).get("name") == "Goal" else 0.0
-            distances.append(distance)
-            angles.append(angle)
-            outcomes.append(outcome)
-
-    if not distances:
-        return np.array([]), np.array([]), np.array([[]])
-
-    dist_bins = np.linspace(0, 40, 17)
-    angle_bins = np.linspace(0, 90, 19)
-
-    counts = np.zeros((len(angle_bins) - 1, len(dist_bins) - 1))
-    goals = np.zeros_like(counts)
-
-    for d, a, o in zip(distances, angles, outcomes):
-        dist_idx = np.searchsorted(dist_bins, d, side="right") - 1
-        angle_idx = np.searchsorted(angle_bins, a, side="right") - 1
-        if 0 <= dist_idx < counts.shape[1] and 0 <= angle_idx < counts.shape[0]:
-            counts[angle_idx, dist_idx] += 1
-            goals[angle_idx, dist_idx] += o
-
-    with np.errstate(divide="ignore", invalid="ignore"):
-        probabilities = np.divide(goals, counts, out=np.zeros_like(goals), where=counts > 0)
-
-    return dist_bins, angle_bins, probabilities
-
-
-def build_shot_quality_figure(dist_bins: np.ndarray, angle_bins: np.ndarray, probabilities: np.ndarray) -> go.Figure:
-    """Create a heatmap describing which shot profiles score most often."""
-
-    if probabilities.size == 0:
-        return go.Figure()
-
-    dist_centers = 0.5 * (dist_bins[:-1] + dist_bins[1:])
-    angle_centers = 0.5 * (angle_bins[:-1] + angle_bins[1:])
-
-    fig = go.Figure(
-        data=[
-            go.Heatmap(
-                z=probabilities,
-                x=dist_centers,
-                y=angle_centers,
-                colorscale="Turbo",
-                colorbar=dict(title="Goal probability"),
-                hovertemplate="Distance: %{x:.1f} yd<br>Angle: %{y:.1f}°<br>Goals: %{z:.3f}<extra></extra>",
-            )
+    return snapshots
+
+
+def pitch_shapes() -> List[dict]:
+    """Return Plotly shape definitions for a stylised pitch."""
+
+    shapes = [
+        # Outer boundary
+        {
+            "type": "rect",
+            "x0": 0,
+            "y0": 0,
+            "x1": PITCH_LENGTH,
+            "y1": PITCH_WIDTH,
+            "line": {"color": "white", "width": 2},
+        },
+        # Half-way line
+        {
+            "type": "line",
+            "x0": PITCH_LENGTH / 2,
+            "y0": 0,
+            "x1": PITCH_LENGTH / 2,
+            "y1": PITCH_WIDTH,
+            "line": {"color": "white", "width": 1},
+        },
+        # Centre circle
+        {
+            "type": "circle",
+            "xref": "x",
+            "yref": "y",
+            "x0": PITCH_LENGTH / 2 - 9.15,
+            "y0": PITCH_WIDTH / 2 - 9.15,
+            "x1": PITCH_LENGTH / 2 + 9.15,
+            "y1": PITCH_WIDTH / 2 + 9.15,
+            "line": {"color": "white", "width": 1},
+        },
+    ]
+
+    # Penalty boxes and six-yard boxes
+    penalty_length = 16.5
+    penalty_width = 40.32
+    six_length = 5.5
+    six_width = 18.32
+
+    shapes.extend(
+        [
+            {
+                "type": "rect",
+                "x0": 0,
+                "y0": (PITCH_WIDTH - penalty_width) / 2,
+                "x1": penalty_length,
+                "y1": (PITCH_WIDTH + penalty_width) / 2,
+                "line": {"color": "white", "width": 1},
+            },
+            {
+                "type": "rect",
+                "x0": PITCH_LENGTH - penalty_length,
+                "y0": (PITCH_WIDTH - penalty_width) / 2,
+                "x1": PITCH_LENGTH,
+                "y1": (PITCH_WIDTH + penalty_width) / 2,
+                "line": {"color": "white", "width": 1},
+            },
+            {
+                "type": "rect",
+                "x0": 0,
+                "y0": (PITCH_WIDTH - six_width) / 2,
+                "x1": six_length,
+                "y1": (PITCH_WIDTH + six_width) / 2,
+                "line": {"color": "white", "width": 1},
+            },
+            {
+                "type": "rect",
+                "x0": PITCH_LENGTH - six_length,
+                "y0": (PITCH_WIDTH - six_width) / 2,
+                "x1": PITCH_LENGTH,
+                "y1": (PITCH_WIDTH + six_width) / 2,
+                "line": {"color": "white", "width": 1},
+            },
         ]
     )
+    return shapes
 
-    fig.update_layout(
-        title="Shot quality by distance and angle",
-        xaxis=dict(title="Distance from goal (yards)"),
-        yaxis=dict(title="Angle to goal (degrees)"),
-        template="plotly_white",
-        width=800,
-        height=550,
+
+def make_animation(
+    snapshots: List[dict],
+    grid_x: int,
+    grid_y: int,
+    title: str,
+    output_path: Path,
+) -> None:
+    """Create and save the interactive Plotly animation."""
+
+    if not snapshots:
+        raise RuntimeError("No freeze-frame events were found for this match.")
+
+    x_centres = np.linspace(PITCH_LENGTH / (2 * grid_x), PITCH_LENGTH - PITCH_LENGTH / (2 * grid_x), grid_x)
+    y_centres = np.linspace(PITCH_WIDTH / (2 * grid_y), PITCH_WIDTH - PITCH_WIDTH / (2 * grid_y), grid_y)
+
+    z_min = min(float(np.min(frame["value_grid"])) for frame in snapshots)
+    z_max = max(float(np.max(frame["value_grid"])) for frame in snapshots)
+    max_abs = max(abs(z_min), abs(z_max))
+    z_min, z_max = -max_abs, max_abs
+
+    initial = snapshots[0]
+    heatmap = go.Heatmap(
+        z=initial["value_grid"],
+        x=x_centres,
+        y=y_centres,
+        colorscale="RdBu",
+        zmin=z_min,
+        zmax=z_max,
+        colorbar=dict(title="State value"),
+        showscale=True,
     )
 
-    return fig
+    teammate_trace = go.Scatter(
+        x=[player["x"] for player in initial["teammates"]],
+        y=[player["y"] for player in initial["teammates"]],
+        mode="markers",
+        marker=dict(size=10, color="#2ca02c"),
+        name="Teammates",
+        text=[player["name"] for player in initial["teammates"]],
+        hovertemplate="%{text}<extra></extra>",
+    )
 
-def main():
-    parser = argparse.ArgumentParser(description="Markov chain value model for StatsBomb open data")
-    parser.add_argument("--competition", type=int, default=43, help="Competition ID (default: FIFA World Cup 2018)")
-    parser.add_argument("--season", type=int, default=3, help="Season ID for the chosen competition")
-    parser.add_argument("--max-matches", type=int, default=15, help="Number of matches to include (limits data size)")
-    parser.add_argument("--output", type=Path, default=Path("value_model.html"), help="Interactive Plotly heatmap output")
-    parser.add_argument("--static-output", type=Path, default=Path("value_model.png"), help="Static Matplotlib summary output")
-    parser.add_argument("--support-output", type=Path, default=Path("support_value.html"), help="Support-aware interactive plot output")
-    parser.add_argument("--progression-output", type=Path, default=Path("ball_progression.png"), help="Average movement quiver plot output")
-    parser.add_argument("--shot-output", type=Path, default=Path("shot_quality.html"), help="Shot quality heatmap output")
-    args = parser.parse_args()
+    opponent_trace = go.Scatter(
+        x=[player["x"] for player in initial["opponents"]],
+        y=[player["y"] for player in initial["opponents"]],
+        mode="markers",
+        marker=dict(size=10, color="#d62728"),
+        name="Opponents",
+        text=[player["name"] for player in initial["opponents"]],
+        hovertemplate="%{text}<extra></extra>",
+    )
 
-    matches = load_matches(args.competition, args.season)
-    if args.max_matches:
-        matches = matches[: args.max_matches]
+    ball_trace = go.Scatter(
+        x=[initial["ball"]["x"]] if initial["ball"]["x"] is not None else [],
+        y=[initial["ball"]["y"]] if initial["ball"]["y"] is not None else [],
+        mode="markers",
+        marker=dict(size=12, color="#ff7f0e", symbol="circle-open"),
+        name="Ball",
+        hoverinfo="skip",
+    )
 
-    print(f"Downloading events for {len(matches)} matches...")
-    matches_events = []
-    matches_with_frames: List[Tuple[List[dict], Dict[str, List[dict]]]] = []
-    for match in matches:
-        match_id = match["match_id"]
-        events = load_match_events(match_id)
-        frames = load_three_sixty(match_id)
-        matches_events.append(events)
-        matches_with_frames.append((events, frames))
-        print(
-            f"Loaded match {match_id} with {len(events)} events"
-            + (f" and {sum(len(f) for f in frames.values())} freeze frames" if frames else "")
+    frames = []
+    slider_steps = []
+    for idx, frame in enumerate(snapshots):
+        description = frame["description"]
+        frames.append(
+            go.Frame(
+                data=[
+                    go.Heatmap(
+                        z=frame["value_grid"],
+                        x=x_centres,
+                        y=y_centres,
+                        zmin=z_min,
+                        zmax=z_max,
+                        colorscale="RdBu",
+                    ),
+                    go.Scatter(
+                        x=[player["x"] for player in frame["teammates"]],
+                        y=[player["y"] for player in frame["teammates"]],
+                        text=[player["name"] for player in frame["teammates"]],
+                    ),
+                    go.Scatter(
+                        x=[player["x"] for player in frame["opponents"]],
+                        y=[player["y"] for player in frame["opponents"]],
+                        text=[player["name"] for player in frame["opponents"]],
+                    ),
+                    go.Scatter(
+                        x=[frame["ball"]["x"]]
+                        if frame["ball"]["x"] is not None
+                        else [],
+                        y=[frame["ball"]["y"]]
+                        if frame["ball"]["y"] is not None
+                        else [],
+                    ),
+                ],
+                name=str(idx),
+                layout=go.Layout(
+                    annotations=[
+                        dict(
+                            x=0,
+                            y=1.05,
+                            xref="paper",
+                            yref="paper",
+                            text=f"{description}<br>Reward: {frame['reward']:.2f}, TD error: {frame['td_error']:.2f}",
+                            showarrow=False,
+                            font=dict(color="white"),
+                        )
+                    ]
+                ),
+            )
+        )
+        slider_steps.append(
+            {
+                "args": [[str(idx)], {"frame": {"duration": 0, "redraw": True}, "mode": "immediate"}],
+                "label": str(idx + 1),
+                "method": "animate",
+            }
         )
 
-    zone_counts, action_counts = build_transition_counts(matches_events)
-    P, goal_probs, _ = counts_to_transition_matrix(zone_counts)
+    fig = go.Figure(data=[heatmap, teammate_trace, opponent_trace, ball_trace], frames=frames)
+    fig.update_layout(
+        title=title,
+        width=1000,
+        height=650,
+        paper_bgcolor="#1b1b1b",
+        plot_bgcolor="#1b1b1b",
+        xaxis=dict(
+            range=[0, PITCH_LENGTH],
+            showgrid=False,
+            zeroline=False,
+            showticklabels=False,
+            scaleanchor="y",
+            scaleratio=1,
+        ),
+        yaxis=dict(
+            range=[0, PITCH_WIDTH],
+            showgrid=False,
+            zeroline=False,
+            showticklabels=False,
+        ),
+        shapes=pitch_shapes(),
+        annotations=[
+            dict(
+                x=0,
+                y=1.05,
+                xref="paper",
+                yref="paper",
+                text=f"{initial['description']}<br>Reward: {initial['reward']:.2f}, TD error: {initial['td_error']:.2f}",
+                showarrow=False,
+                font=dict(color="white"),
+            )
+        ],
+        sliders=[
+            {
+                "active": 0,
+                "currentvalue": {"prefix": "Event: ", "font": {"color": "white"}},
+                "pad": {"t": 50, "b": 10},
+                "steps": slider_steps,
+            }
+        ],
+        updatemenus=[
+            {
+                "type": "buttons",
+                "buttons": [
+                    {
+                        "label": "Play",
+                        "method": "animate",
+                        "args": [None, {"frame": {"duration": 600, "redraw": True}, "fromcurrent": True}],
+                    },
+                    {
+                        "label": "Pause",
+                        "method": "animate",
+                        "args": [[None], {"mode": "immediate", "frame": {"duration": 0, "redraw": True}}],
+                    },
+                ],
+                "direction": "left",
+                "pad": {"r": 10, "t": 50},
+                "x": 0.1,
+                "y": 0,
+                "showactive": False,
+                "bgcolor": "#333333",
+                "bordercolor": "#444444",
+            }
+        ],
+        legend=dict(bgcolor="rgba(0,0,0,0)", font=dict(color="white")),
+    )
 
-    state_values = solve_state_value(P, goal_probs, gamma=1.0)
-    discounted_state_values = solve_state_value(P, goal_probs, gamma=0.9)
-    action_values = compute_action_values(action_counts, state_values)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.write_html(str(output_path), include_plotlyjs="cdn", auto_play=False)
 
-    fig = build_interactive_figure(state_values, discounted_state_values, action_values)
-    fig.write_html(str(args.output), include_plotlyjs="cdn")
-    print(f"Saved interactive visualisation to {args.output.resolve()}")
 
-    if plt is not None:
-        create_static_value_figure(state_values, discounted_state_values, action_values, args.static_output)
-        print(f"Saved static summary to {args.static_output.resolve()}")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Visualise a StatsBomb 360 Markov value model with interactive playback.",
+    )
+    parser.add_argument(
+        "--competition-id",
+        type=int,
+        help="Limit to a specific competition ID when searching for matches.",
+    )
+    parser.add_argument(
+        "--season-id",
+        type=int,
+        help="Limit to a specific season ID when searching for matches.",
+    )
+    parser.add_argument(
+        "--match-id",
+        type=int,
+        help="Use a specific match_id (must have StatsBomb 360 data).",
+    )
+    parser.add_argument(
+        "--max-matches",
+        type=int,
+        default=5,
+        help="Maximum matches to scan when searching for 360 data.",
+    )
+    parser.add_argument(
+        "--grid-x",
+        type=int,
+        default=12,
+        help="Number of grid columns for the value function.",
+    )
+    parser.add_argument(
+        "--grid-y",
+        type=int,
+        default=8,
+        help="Number of grid rows for the value function.",
+    )
+    parser.add_argument(
+        "--gamma",
+        type=float,
+        default=0.95,
+        help="Discount factor for the temporal-difference update.",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.4,
+        help="Learning rate for the temporal-difference update.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("three_sixty_markov.html"),
+        help="Output HTML file for the interactive animation.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List discovered matches with 360 data and exit.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    matches = discover_three_sixty_matches(
+        competition_filter=args.competition_id,
+        season_filter=args.season_id,
+        limit=args.max_matches,
+    )
+
+    if args.list:
+        if not matches:
+            print("No matches with StatsBomb 360 data were found for the given filters.")
+            return
+        print("Matches with StatsBomb 360 data:")
+        for summary in matches:
+            print(
+                f"match_id={summary.match_id} | {summary.match_date} | "
+                f"{summary.home_team} vs {summary.away_team} | "
+                f"{summary.competition_name} {summary.season_name} | "
+                f"freeze frames: {summary.freeze_frame_events}"
+            )
+        return
+
+    target_match: Optional[MatchSummary] = None
+    if args.match_id is not None:
+        for summary in matches:
+            if summary.match_id == args.match_id:
+                target_match = summary
+                break
+        if target_match is None:
+            # If the requested match wasn't in the limited search, fetch directly.
+            freeze_frames = load_freeze_frames(args.match_id)
+            if not freeze_frames:
+                raise RuntimeError(
+                    f"Match {args.match_id} does not have StatsBomb 360 data available."
+                )
+            # We need metadata to label the animation; attempt to locate it.
+            for competition in load_competitions():
+                comp_id = int(competition["competition_id"])
+                season_id = int(competition["season_id"])
+                matches_meta = load_matches(comp_id, season_id)
+                for match in matches_meta:
+                    if int(match["match_id"]) == args.match_id:
+                        target_match = MatchSummary(
+                            competition_id=comp_id,
+                            competition_name=competition.get("competition_name", ""),
+                            season_id=season_id,
+                            season_name=competition.get("season_name", ""),
+                            match_id=args.match_id,
+                            home_team=match.get("home_team", {}).get("home_team_name", ""),
+                            away_team=match.get("away_team", {}).get("away_team_name", ""),
+                            match_date=match.get("match_date", ""),
+                            freeze_frame_events=sum(
+                                1 for frame in freeze_frames.values() if frame
+                            ),
+                        )
+                        break
+                if target_match:
+                    break
+            if target_match is None:
+                raise RuntimeError(
+                    "Unable to locate metadata for the requested match, "
+                    "even though 360 data exists."
+                )
     else:
-        print("Matplotlib not installed – skipping static summary output.")
+        if not matches:
+            raise RuntimeError(
+                "No matches with StatsBomb 360 data were found. Try increasing --max-matches "
+                "or adjusting the competition/season filters."
+            )
+        target_match = matches[0]
 
-    support_maps = compute_support_state_values(matches_with_frames)
-    if support_maps:
-        support_fig = build_support_figure(support_maps)
-        support_fig.write_html(str(args.support_output), include_plotlyjs="cdn")
-        print(f"Saved support-context visualisation to {args.support_output.resolve()}")
-    else:
-        print("No StatsBomb 360 freeze frames available for support-context visualisation.")
+    assert target_match is not None
+    freeze_frames = load_freeze_frames(target_match.match_id)
+    if not freeze_frames:
+        raise RuntimeError(
+            f"Match {target_match.match_id} no longer exposes StatsBomb 360 data."
+        )
 
-    vectors = compute_ball_progression_vectors(matches_events)
-    if plt is not None and vectors:
-        create_progression_plot(vectors, args.progression_output)
-        print(f"Saved ball progression plot to {args.progression_output.resolve()}")
-    elif plt is None:
-        print("Matplotlib not installed – skipping ball progression plot.")
-    else:
-        print("Insufficient passing/carry data for progression plot.")
+    events = load_events(target_match.match_id)
+    snapshots = build_value_snapshots(
+        events,
+        freeze_frames,
+        grid_x=args.grid_x,
+        grid_y=args.grid_y,
+        gamma=args.gamma,
+        alpha=args.alpha,
+    )
 
-    dist_bins, angle_bins, probabilities = compute_shot_quality(matches_events)
-    if probabilities.size:
-        shot_fig = build_shot_quality_figure(dist_bins, angle_bins, probabilities)
-        shot_fig.write_html(str(args.shot_output), include_plotlyjs="cdn")
-        print(f"Saved shot quality visualisation to {args.shot_output.resolve()}")
-    else:
-        print("No shot data available for shot quality visualisation.")
+    title = (
+        f"{target_match.home_team} vs {target_match.away_team} ({target_match.match_date})<br>"
+        f"{target_match.competition_name} {target_match.season_name}"
+    )
+    make_animation(snapshots, args.grid_x, args.grid_y, title, args.output)
+    print(f"Interactive animation saved to {args.output.resolve()}")
 
 
 if __name__ == "__main__":

--- a/markov_value_model.py
+++ b/markov_value_model.py
@@ -1,13 +1,18 @@
-"""Simple Markov chain value model for StatsBomb open data.
+"""Enhanced Markov chain value model for StatsBomb open data.
 
 This script downloads a sample of StatsBomb open-data matches, builds a
 possession-based Markov chain that approximates Ian Graham's possession value
-model, and produces an interactive Plotly heatmap that visualises the value of
-different actions from different pitch locations.
+model, and produces a suite of visualisations:
+
+* an interactive Plotly heatmap with higher-resolution grids and goal markers,
+* a static Matplotlib figure for presentations,
+* a support-aware model using StatsBomb 360 freeze frames,
+* an average ball-progression quiver plot, and
+* a shot quality heatmap by distance and angle.
 
 Usage (from the repository root):
 
-    python markov_value_model.py --max-matches 20 --output value_model.html
+    python markov_value_model.py --max-matches 20
 
 The script keeps the file structure intentionally simple so it can be dropped
 into presentations or notebooks without additional project scaffolding.
@@ -18,19 +23,29 @@ from __future__ import annotations
 import argparse
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple
 
+try:
+    import matplotlib.pyplot as plt
+except ImportError:  # pragma: no cover - optional dependency
+    plt = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover
+    from matplotlib.axes import Axes
 import numpy as np
 import plotly.graph_objects as go
 import requests
+from requests.exceptions import HTTPError
 
 STATS_BOMB_BASE = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
 
 # Pitch and grid settings (StatsBomb pitch: 120 x 80 coordinates)
 PITCH_LENGTH = 120.0
 PITCH_WIDTH = 80.0
-GRID_X = 6
-GRID_Y = 4
+GRID_X = 12
+GRID_Y = 8
+CELL_LENGTH = PITCH_LENGTH / GRID_X
+CELL_WIDTH = PITCH_WIDTH / GRID_Y
 
 
 def fetch_json(url: str) -> list:
@@ -53,6 +68,23 @@ def load_match_events(match_id: int) -> list:
 
     url = f"{STATS_BOMB_BASE}/events/{match_id}.json"
     return fetch_json(url)
+
+
+def load_three_sixty(match_id: int) -> Dict[str, list]:
+    """Fetch StatsBomb 360 freeze frames for a match (if available)."""
+
+    url = f"{STATS_BOMB_BASE}/three-sixty/{match_id}.json"
+    try:
+        frames = fetch_json(url)
+    except HTTPError:
+        return {}
+
+    frame_map = {}
+    for frame in frames:
+        event_uuid = frame.get("event_uuid")
+        if event_uuid:
+            frame_map[event_uuid] = frame.get("freeze_frame", [])
+    return frame_map
 
 
 def location_to_zone(location: Sequence[float]) -> Optional[int]:
@@ -239,6 +271,81 @@ def grid_from_values(values: Dict[int, float], default: Optional[float] = None) 
     return grid
 
 
+def grid_centres() -> Tuple[np.ndarray, np.ndarray]:
+    """Return the x/y coordinates for the centre of each zone cell."""
+
+    x_centers = np.linspace(CELL_LENGTH / 2, PITCH_LENGTH - CELL_LENGTH / 2, GRID_X)
+    y_centers = np.linspace(PITCH_WIDTH - CELL_WIDTH / 2, CELL_WIDTH / 2, GRID_Y)
+    return x_centers, y_centers
+
+
+def create_pitch_shapes() -> List[dict]:
+    """Return Plotly shape definitions for a simple pitch with goals."""
+
+    penalty_width = 44.0
+    six_yard_width = 20.0
+    goal_width = 8.0
+    penalty_depth = 18.0
+    six_yard_depth = 6.0
+    goal_depth = 2.0
+    center_y = PITCH_WIDTH / 2
+
+    shapes: List[dict] = [
+        dict(type="rect", x0=0, y0=0, x1=PITCH_LENGTH, y1=PITCH_WIDTH, line=dict(color="black", width=2)),
+        dict(type="line", x0=PITCH_LENGTH / 2, y0=0, x1=PITCH_LENGTH / 2, y1=PITCH_WIDTH, line=dict(color="black", width=1)),
+        dict(
+            type="circle",
+            x0=PITCH_LENGTH / 2 - 10,
+            y0=center_y - 10,
+            x1=PITCH_LENGTH / 2 + 10,
+            y1=center_y + 10,
+            line=dict(color="black", width=1),
+        ),
+    ]
+
+    for side in (0, PITCH_LENGTH - penalty_depth):
+        direction = 1 if side == 0 else -1
+        x0 = side
+        x1 = side + direction * penalty_depth
+        shapes.append(
+            dict(
+                type="rect",
+                x0=min(x0, x1),
+                x1=max(x0, x1),
+                y0=center_y - penalty_width / 2,
+                y1=center_y + penalty_width / 2,
+                line=dict(color="black", width=1),
+            )
+        )
+        x0 = side
+        x1 = side + direction * six_yard_depth
+        shapes.append(
+            dict(
+                type="rect",
+                x0=min(x0, x1),
+                x1=max(x0, x1),
+                y0=center_y - six_yard_width / 2,
+                y1=center_y + six_yard_width / 2,
+                line=dict(color="black", width=1),
+            )
+        )
+        goal_x0 = side - direction * goal_depth
+        goal_x1 = side
+        shapes.append(
+            dict(
+                type="rect",
+                x0=min(goal_x0, goal_x1),
+                x1=max(goal_x0, goal_x1),
+                y0=center_y - goal_width / 2,
+                y1=center_y + goal_width / 2,
+                line=dict(color="black", width=2),
+                fillcolor="rgba(200,200,200,0.3)",
+            )
+        )
+
+    return shapes
+
+
 def build_interactive_figure(
     state_values: np.ndarray,
     discounted_state_values: np.ndarray,
@@ -250,19 +357,38 @@ def build_interactive_figure(
     zone_value_map = {zone: state_values[zone] for zone in range(num_zones)}
     discounted_map = {zone: discounted_state_values[zone] for zone in range(num_zones)}
 
-    heatmaps = []
-    labels = []
+    heatmaps: List[Dict[str, object]] = []
 
-    heatmaps.append(grid_from_values(zone_value_map))
-    labels.append("State Value (xG probability)")
+    def append_heatmap(matrix: np.ndarray, label: str, *, diverging: bool = False, colorbar: str = "xG") -> None:
+        finite = matrix[np.isfinite(matrix)]
+        if finite.size == 0:
+            zmin, zmax = (0.0, 1.0)
+        else:
+            zmin, zmax = float(finite.min()), float(finite.max())
+        colorscale = "YlOrRd"
+        if diverging:
+            bound = max(abs(zmin), abs(zmax)) or 1.0
+            zmin, zmax = -bound, bound
+            colorscale = "RdBu"
+        elif zmin == zmax:
+            zmax = zmin + 1e-6
 
-    heatmaps.append(grid_from_values(discounted_map))
-    labels.append("Discounted Value (quick chance focus)")
+        heatmaps.append(
+            {
+                "matrix": matrix,
+                "label": label,
+                "zmin": zmin,
+                "zmax": zmax,
+                "colorscale": colorscale,
+                "colorbar": colorbar,
+            }
+        )
 
-    # Aggregate action values and advantage (RL-style improvement over average)
+    append_heatmap(grid_from_values(zone_value_map), "State Value (xG probability)")
+    append_heatmap(grid_from_values(discounted_map), "Discounted Value (quick chance focus)")
+
     base_values = state_values.copy()
     actions_by_name = sorted({action for _, action in action_values.keys()})
-
     for action in actions_by_name:
         action_map = {}
         advantage_map = {}
@@ -273,27 +399,29 @@ def build_interactive_figure(
                 advantage_map[zone] = action_values[key] - base_values[zone]
 
         if action_map:
-            heatmaps.append(grid_from_values(action_map))
-            labels.append(f"Action Value: {action}")
-
+            append_heatmap(grid_from_values(action_map), f"Action Value: {action}")
         if advantage_map:
-            heatmaps.append(grid_from_values(advantage_map))
-            labels.append(f"Action Advantage: {action}")
+            append_heatmap(
+                grid_from_values(advantage_map),
+                f"Action Advantage: {action}",
+                diverging=True,
+                colorbar="Advantage",
+            )
 
-    x_labels = [f"Zone {x + 1}" for x in range(GRID_X)]
-    y_labels = [f"Band {GRID_Y - y}" for y in range(GRID_Y)]
+    x_centers, y_centers = grid_centres()
 
     traces = []
-    for heatmap in heatmaps:
+    for spec in heatmaps:
         traces.append(
             go.Heatmap(
-                z=heatmap,
-                x=x_labels,
-                y=y_labels,
-                colorscale="YlOrRd",
-                zmin=0,
-                zmax=float(np.nanmax(heatmap)) if np.isfinite(np.nanmax(heatmap)) else 1.0,
-                colorbar=dict(title="xG"),
+                z=spec["matrix"],
+                x=x_centers,
+                y=y_centers,
+                colorscale=spec["colorscale"],
+                zmin=spec["zmin"],
+                zmax=spec["zmax"],
+                colorbar=dict(title=spec["colorbar"]),
+                hovertemplate="x: %{x:.1f}<br>y: %{y:.1f}<br>value: %{z:.3f}<extra></extra>",
                 visible=False,
             )
         )
@@ -304,28 +432,462 @@ def build_interactive_figure(
     fig = go.Figure(data=traces)
 
     buttons = []
-    for idx, label in enumerate(labels):
+    for idx, spec in enumerate(heatmaps):
         visibility = [False] * len(traces)
         visibility[idx] = True
-        buttons.append(dict(label=label, method="update", args=[{"visible": visibility}, {"title": label}]))
+        buttons.append(
+            dict(label=spec["label"], method="update", args=[{"visible": visibility}, {"title": spec["label"]}])
+        )
 
     fig.update_layout(
-        title=labels[0] if labels else "Markov Chain Value Model",
-        xaxis=dict(title="Pitch length (left to right)", side="top"),
-        yaxis=dict(title="Pitch width", autorange="reversed"),
-        updatemenus=[dict(buttons=buttons, direction="down", showactive=True)],
+        title=heatmaps[0]["label"] if heatmaps else "Markov Chain Value Model",
+        xaxis=dict(title="Pitch length (yards)", range=[0, PITCH_LENGTH], constrain="domain"),
+        yaxis=dict(title="Pitch width (yards)", range=[PITCH_WIDTH, 0], scaleanchor="x", scaleratio=1),
+        updatemenus=[dict(buttons=buttons, direction="down", showactive=True, x=1.05, xanchor="left")],
         template="plotly_white",
+        shapes=create_pitch_shapes(),
+        width=950,
+        height=600,
     )
 
     return fig
 
+
+def draw_pitch(ax: "Axes") -> None:
+    """Render a simple football pitch with goals onto a Matplotlib axis."""
+
+    ax.set_xlim(0, PITCH_LENGTH)
+    ax.set_ylim(0, PITCH_WIDTH)
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+    # Outer lines and halfway line
+    ax.plot([0, PITCH_LENGTH, PITCH_LENGTH, 0, 0], [0, 0, PITCH_WIDTH, PITCH_WIDTH, 0], color="black", linewidth=1.5)
+    ax.plot([PITCH_LENGTH / 2, PITCH_LENGTH / 2], [0, PITCH_WIDTH], color="black", linewidth=1)
+
+    center_circle = plt.Circle((PITCH_LENGTH / 2, PITCH_WIDTH / 2), 10, fill=False, color="black", linewidth=1)
+    ax.add_patch(center_circle)
+
+    penalty_width = 44.0
+    penalty_depth = 18.0
+    six_width = 20.0
+    six_depth = 6.0
+    goal_width = 8.0
+    goal_depth = 2.0
+    center_y = PITCH_WIDTH / 2
+
+    for side in (0, PITCH_LENGTH):
+        direction = 1 if side == 0 else -1
+        penalty = plt.Rectangle(
+            (side - (1 - direction) * penalty_depth, center_y - penalty_width / 2),
+            penalty_depth * direction,
+            penalty_width,
+            fill=False,
+            color="black",
+            linewidth=1,
+        )
+        six = plt.Rectangle(
+            (side - (1 - direction) * six_depth, center_y - six_width / 2),
+            six_depth * direction,
+            six_width,
+            fill=False,
+            color="black",
+            linewidth=1,
+        )
+        goal = plt.Rectangle(
+            (side - (1 - direction) * goal_depth, center_y - goal_width / 2),
+            goal_depth * direction,
+            goal_width,
+            fill=True,
+            facecolor="lightgrey",
+            edgecolor="black",
+            linewidth=1,
+            alpha=0.4,
+        )
+        ax.add_patch(penalty)
+        ax.add_patch(six)
+        ax.add_patch(goal)
+
+
+def render_static_heatmap(ax: "Axes", matrix: np.ndarray, title: str, *, cmap: str = "YlOrRd", diverging: bool = False) -> None:
+    """Render a heatmap atop the pitch background."""
+
+    draw_pitch(ax)
+    finite = matrix[np.isfinite(matrix)]
+    if finite.size == 0:
+        vmin, vmax = (0.0, 1.0)
+    else:
+        vmin, vmax = float(finite.min()), float(finite.max())
+
+    if diverging:
+        bound = max(abs(vmin), abs(vmax)) or 1.0
+        vmin, vmax = -bound, bound
+        cmap = "RdBu_r"
+    elif vmin == vmax:
+        vmax = vmin + 1e-6
+
+    ax.imshow(
+        np.ma.masked_invalid(matrix),
+        extent=[0, PITCH_LENGTH, 0, PITCH_WIDTH],
+        origin="upper",
+        cmap=cmap,
+        vmin=vmin,
+        vmax=vmax,
+        alpha=0.85,
+    )
+    ax.set_title(title)
+
+
+def create_static_value_figure(
+    state_values: np.ndarray,
+    discounted_state_values: np.ndarray,
+    action_values: Dict[Tuple[int, str], float],
+    output: Path,
+) -> None:
+    """Save a Matplotlib figure highlighting key value surfaces."""
+
+    num_zones = GRID_X * GRID_Y
+    base_map = {zone: state_values[zone] for zone in range(num_zones)}
+    discounted_map = {zone: discounted_state_values[zone] for zone in range(num_zones)}
+
+    # Choose the two most common actions by coverage
+    action_coverage = Counter()
+    for (zone, action), value in action_values.items():
+        if value:
+            action_coverage[action] += 1
+
+    most_common = [action for action, _ in action_coverage.most_common(2)]
+    action_grids = []
+    for action in most_common:
+        action_map = {zone: value for (zone, name), value in action_values.items() if name == action}
+        action_grids.append((action, grid_from_values(action_map)))
+
+    if plt is None:
+        raise RuntimeError("Matplotlib is required for static output")
+
+    fig, axes = plt.subplots(1, 2 + len(action_grids), figsize=(5 * (2 + len(action_grids)), 6))
+    if not isinstance(axes, np.ndarray):
+        axes = np.array([axes])
+
+    render_static_heatmap(axes[0], grid_from_values(base_map), "State value")
+    render_static_heatmap(
+        axes[1],
+        grid_from_values(discounted_map),
+        "Discounted value",
+    )
+
+    for idx, (action, matrix) in enumerate(action_grids, start=2):
+        render_static_heatmap(axes[idx], matrix, f"Action value: {action}")
+
+    fig.tight_layout()
+    fig.savefig(output, dpi=200)
+    plt.close(fig)
+
+
+def possession_goal_outcome(events: List[dict], start_idx: int, possession_id: int, team_id: int) -> bool:
+    """Return True if the possession results in a goal for the given team."""
+
+    for event in events[start_idx:]:
+        if event.get("possession") != possession_id:
+            break
+        if event.get("team", {}).get("id") != team_id:
+            continue
+        shot = event.get("shot")
+        if shot and shot.get("outcome", {}).get("name") == "Goal":
+            return True
+    return False
+
+
+def freeze_frame_support_label(freeze_frame: List[dict], location: Sequence[float]) -> str:
+    """Encode supporting player context into a categorical label."""
+
+    if not location or len(location) < 2:
+        return "unknown"
+
+    teammates_near = 0
+    opponents_near = 0
+    teammates_ahead = 0
+
+    for frame in freeze_frame:
+        point = frame.get("location")
+        if not point or len(point) < 2:
+            continue
+        dx = point[0] - location[0]
+        dy = point[1] - location[1]
+        distance = float(np.hypot(dx, dy))
+        if frame.get("teammate"):
+            if distance <= 15:
+                teammates_near += 1
+            if dx > 0:
+                teammates_ahead += 1
+        else:
+            if distance <= 10:
+                opponents_near += 1
+
+    if teammates_near == 0:
+        support = "isolated"
+    elif teammates_near <= 2:
+        support = "supported"
+    else:
+        support = "overload"
+
+    if opponents_near == 0:
+        pressure = "free"
+    elif opponents_near == 1:
+        pressure = "pressure"
+    else:
+        pressure = "crowded"
+
+    ahead = "no_lane" if teammates_ahead == 0 else "lane"
+    return f"{support}/{pressure}/{ahead}"
+
+
+def compute_support_state_values(
+    matches_events: Iterable[Tuple[List[dict], Dict[str, List[dict]]]]
+) -> Dict[str, Dict[int, float]]:
+    """Estimate scoring probability conditioned on support context states."""
+
+    totals: Dict[Tuple[str, int], Counter] = defaultdict(Counter)
+
+    for events, frame_map in matches_events:
+        event_index = {event.get("id"): idx for idx, event in enumerate(events)}
+        for event_id, freeze_frame in frame_map.items():
+            idx = event_index.get(event_id)
+            if idx is None:
+                continue
+
+            event = events[idx]
+            zone = location_to_zone(event.get("location"))
+            if zone is None:
+                continue
+
+            team = event.get("team", {}).get("id")
+            possession_id = event.get("possession")
+            if team is None or possession_id is None:
+                continue
+
+            label = freeze_frame_support_label(freeze_frame, event.get("location", []))
+            goal = possession_goal_outcome(events, idx, possession_id, team)
+            totals[(label, zone)]["count"] += 1
+            if goal:
+                totals[(label, zone)]["goals"] += 1
+
+    support_maps: Dict[str, Dict[int, float]] = defaultdict(dict)
+    for (label, zone), counts in totals.items():
+        count = counts["count"]
+        goals = counts["goals"]
+        if count > 0:
+            support_maps[label][zone] = goals / count
+
+    return dict(support_maps)
+
+
+def build_support_figure(support_maps: Dict[str, Dict[int, float]]) -> go.Figure:
+    """Create a dropdown heatmap for the support-aware state values."""
+
+    x_centers, y_centers = grid_centres()
+    heatmaps = []
+    for label, zone_map in sorted(support_maps.items(), key=lambda item: item[0]):
+        matrix = grid_from_values(zone_map, default=np.nan)
+        finite = matrix[np.isfinite(matrix)]
+        if finite.size == 0:
+            continue
+        heatmaps.append((label, matrix, float(finite.min()), float(finite.max())))
+
+    traces = []
+    for label, matrix, vmin, vmax in heatmaps:
+        traces.append(
+            go.Heatmap(
+                z=matrix,
+                x=x_centers,
+                y=y_centers,
+                colorscale="Viridis",
+                zmin=vmin,
+                zmax=vmax,
+                colorbar=dict(title="xG"),
+                hovertemplate="x: %{x:.1f}<br>y: %{y:.1f}<br>value: %{z:.3f}<extra></extra>",
+                visible=False,
+            )
+        )
+
+    if traces:
+        traces[0].visible = True
+
+    buttons = []
+    for idx, (label, _, _, _) in enumerate(heatmaps):
+        visibility = [False] * len(traces)
+        visibility[idx] = True
+        buttons.append(dict(label=label, method="update", args=[{"visible": visibility}, {"title": label}]))
+
+    fig = go.Figure(data=traces)
+    fig.update_layout(
+        title=heatmaps[0][0] if heatmaps else "Support context value",
+        xaxis=dict(title="Pitch length (yards)", range=[0, PITCH_LENGTH], constrain="domain"),
+        yaxis=dict(title="Pitch width (yards)", range=[PITCH_WIDTH, 0], scaleanchor="x", scaleratio=1),
+        updatemenus=[dict(buttons=buttons, direction="down", showactive=True, x=1.05, xanchor="left")],
+        template="plotly_white",
+        shapes=create_pitch_shapes(),
+        width=950,
+        height=600,
+    )
+    return fig
+
+
+def compute_ball_progression_vectors(matches_events: Iterable[List[dict]]) -> Dict[int, Tuple[float, float, int]]:
+    """Compute average ball movement vectors (dx, dy, count) from each zone."""
+
+    vectors: Dict[int, List[Tuple[float, float]]] = defaultdict(list)
+
+    for events in matches_events:
+        for event in events:
+            zone = location_to_zone(event.get("location"))
+            if zone is None:
+                continue
+
+            end_location: Optional[Sequence[float]] = None
+            if "pass" in event:
+                end_location = event["pass"].get("end_location")
+            elif "carry" in event:
+                end_location = event["carry"].get("end_location")
+
+            if end_location and len(end_location) >= 2:
+                dx = end_location[0] - event["location"][0]
+                dy = end_location[1] - event["location"][1]
+                vectors[zone].append((dx, dy))
+
+    aggregated: Dict[int, Tuple[float, float, int]] = {}
+    for zone, displacements in vectors.items():
+        if displacements:
+            dxs, dys = zip(*displacements)
+            aggregated[zone] = (float(np.mean(dxs)), float(np.mean(dys)), len(displacements))
+
+    return aggregated
+
+
+def create_progression_plot(vectors: Dict[int, Tuple[float, float, int]], output: Path) -> None:
+    """Render a quiver plot showing average ball progression from each zone."""
+
+    if plt is None:
+        raise RuntimeError("Matplotlib is required for the progression plot")
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    draw_pitch(ax)
+
+    x_centers, y_centers = grid_centres()
+    X, Y = np.meshgrid(x_centers, y_centers)
+    U = np.zeros_like(X)
+    V = np.zeros_like(Y)
+    for zone, (dx, dy, count) in vectors.items():
+        x_idx, y_idx = zone_to_grid(zone)
+        row = GRID_Y - 1 - y_idx
+        col = x_idx
+        U[row, col] = dx
+        V[row, col] = -dy  # invert y-axis for plotting
+
+    magnitude = np.hypot(U, V)
+    max_mag = np.nanmax(magnitude) if np.isfinite(np.nanmax(magnitude)) else 1.0
+    scale = max_mag if max_mag else 1.0
+
+    quiver = ax.quiver(X, Y, U, V, magnitude, angles="xy", scale_units="xy", scale=1.5 * scale, cmap="plasma")
+    cbar = fig.colorbar(quiver, ax=ax)
+    cbar.set_label("Average movement (yards)")
+    ax.set_title("Average ball progression for passes and carries")
+    fig.tight_layout()
+    fig.savefig(output, dpi=200)
+    plt.close(fig)
+
+
+def compute_shot_quality(events: Iterable[List[dict]]) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute goal probability by shot distance and angle bins."""
+
+    distances = []
+    angles = []
+    outcomes = []
+
+    goal_center = np.array([PITCH_LENGTH, PITCH_WIDTH / 2])
+
+    for match_events in events:
+        for event in match_events:
+            shot = event.get("shot")
+            if not shot:
+                continue
+            location = event.get("location")
+            if not location or len(location) < 2:
+                continue
+            point = np.array(location[:2])
+            vector = goal_center - point
+            distance = float(np.hypot(vector[0], vector[1]))
+            angle = float(np.degrees(np.arctan2(abs(vector[1]), vector[0])))
+            outcome = 1.0 if shot.get("outcome", {}).get("name") == "Goal" else 0.0
+            distances.append(distance)
+            angles.append(angle)
+            outcomes.append(outcome)
+
+    if not distances:
+        return np.array([]), np.array([]), np.array([[]])
+
+    dist_bins = np.linspace(0, 40, 17)
+    angle_bins = np.linspace(0, 90, 19)
+
+    counts = np.zeros((len(angle_bins) - 1, len(dist_bins) - 1))
+    goals = np.zeros_like(counts)
+
+    for d, a, o in zip(distances, angles, outcomes):
+        dist_idx = np.searchsorted(dist_bins, d, side="right") - 1
+        angle_idx = np.searchsorted(angle_bins, a, side="right") - 1
+        if 0 <= dist_idx < counts.shape[1] and 0 <= angle_idx < counts.shape[0]:
+            counts[angle_idx, dist_idx] += 1
+            goals[angle_idx, dist_idx] += o
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        probabilities = np.divide(goals, counts, out=np.zeros_like(goals), where=counts > 0)
+
+    return dist_bins, angle_bins, probabilities
+
+
+def build_shot_quality_figure(dist_bins: np.ndarray, angle_bins: np.ndarray, probabilities: np.ndarray) -> go.Figure:
+    """Create a heatmap describing which shot profiles score most often."""
+
+    if probabilities.size == 0:
+        return go.Figure()
+
+    dist_centers = 0.5 * (dist_bins[:-1] + dist_bins[1:])
+    angle_centers = 0.5 * (angle_bins[:-1] + angle_bins[1:])
+
+    fig = go.Figure(
+        data=[
+            go.Heatmap(
+                z=probabilities,
+                x=dist_centers,
+                y=angle_centers,
+                colorscale="Turbo",
+                colorbar=dict(title="Goal probability"),
+                hovertemplate="Distance: %{x:.1f} yd<br>Angle: %{y:.1f}°<br>Goals: %{z:.3f}<extra></extra>",
+            )
+        ]
+    )
+
+    fig.update_layout(
+        title="Shot quality by distance and angle",
+        xaxis=dict(title="Distance from goal (yards)"),
+        yaxis=dict(title="Angle to goal (degrees)"),
+        template="plotly_white",
+        width=800,
+        height=550,
+    )
+
+    return fig
 
 def main():
     parser = argparse.ArgumentParser(description="Markov chain value model for StatsBomb open data")
     parser.add_argument("--competition", type=int, default=43, help="Competition ID (default: FIFA World Cup 2018)")
     parser.add_argument("--season", type=int, default=3, help="Season ID for the chosen competition")
     parser.add_argument("--max-matches", type=int, default=15, help="Number of matches to include (limits data size)")
-    parser.add_argument("--output", type=Path, default=Path("value_model.html"), help="Where to save the interactive plot")
+    parser.add_argument("--output", type=Path, default=Path("value_model.html"), help="Interactive Plotly heatmap output")
+    parser.add_argument("--static-output", type=Path, default=Path("value_model.png"), help="Static Matplotlib summary output")
+    parser.add_argument("--support-output", type=Path, default=Path("support_value.html"), help="Support-aware interactive plot output")
+    parser.add_argument("--progression-output", type=Path, default=Path("ball_progression.png"), help="Average movement quiver plot output")
+    parser.add_argument("--shot-output", type=Path, default=Path("shot_quality.html"), help="Shot quality heatmap output")
     args = parser.parse_args()
 
     matches = load_matches(args.competition, args.season)
@@ -334,11 +896,17 @@ def main():
 
     print(f"Downloading events for {len(matches)} matches...")
     matches_events = []
+    matches_with_frames: List[Tuple[List[dict], Dict[str, List[dict]]]] = []
     for match in matches:
         match_id = match["match_id"]
         events = load_match_events(match_id)
+        frames = load_three_sixty(match_id)
         matches_events.append(events)
-        print(f"Loaded match {match_id} with {len(events)} events")
+        matches_with_frames.append((events, frames))
+        print(
+            f"Loaded match {match_id} with {len(events)} events"
+            + (f" and {sum(len(f) for f in frames.values())} freeze frames" if frames else "")
+        )
 
     zone_counts, action_counts = build_transition_counts(matches_events)
     P, goal_probs, _ = counts_to_transition_matrix(zone_counts)
@@ -349,8 +917,38 @@ def main():
 
     fig = build_interactive_figure(state_values, discounted_state_values, action_values)
     fig.write_html(str(args.output), include_plotlyjs="cdn")
-
     print(f"Saved interactive visualisation to {args.output.resolve()}")
+
+    if plt is not None:
+        create_static_value_figure(state_values, discounted_state_values, action_values, args.static_output)
+        print(f"Saved static summary to {args.static_output.resolve()}")
+    else:
+        print("Matplotlib not installed – skipping static summary output.")
+
+    support_maps = compute_support_state_values(matches_with_frames)
+    if support_maps:
+        support_fig = build_support_figure(support_maps)
+        support_fig.write_html(str(args.support_output), include_plotlyjs="cdn")
+        print(f"Saved support-context visualisation to {args.support_output.resolve()}")
+    else:
+        print("No StatsBomb 360 freeze frames available for support-context visualisation.")
+
+    vectors = compute_ball_progression_vectors(matches_events)
+    if plt is not None and vectors:
+        create_progression_plot(vectors, args.progression_output)
+        print(f"Saved ball progression plot to {args.progression_output.resolve()}")
+    elif plt is None:
+        print("Matplotlib not installed – skipping ball progression plot.")
+    else:
+        print("Insufficient passing/carry data for progression plot.")
+
+    dist_bins, angle_bins, probabilities = compute_shot_quality(matches_events)
+    if probabilities.size:
+        shot_fig = build_shot_quality_figure(dist_bins, angle_bins, probabilities)
+        shot_fig.write_html(str(args.shot_output), include_plotlyjs="cdn")
+        print(f"Saved shot quality visualisation to {args.shot_output.resolve()}")
+    else:
+        print("No shot data available for shot quality visualisation.")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+plotly
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 plotly
 requests
-matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 plotly
 requests
+matplotlib


### PR DESCRIPTION
## Summary
- add a lightweight `markov_value_model.py` script that downloads StatsBomb open data and estimates Ian Graham-style possession values with an action-level Markov chain
- output an interactive Plotly heatmap with state value, discounted value, and action/advantage views for different on-ball actions
- document setup and usage steps plus dependencies in a simple README and requirements file

## Testing
- python -m compileall markov_value_model.py
- pip install -r requirements.txt *(fails: proxy 403 when resolving packages)*

------
https://chatgpt.com/codex/tasks/task_b_68d3d78e0b48832a94125f60952bc4ae