### PR TITLE
Add StatsBomb 360 match replay generator

### DIFF
--- a/replay_generator.py
+++ b/replay_generator.py
@@ -1,1434 +1,1091 @@
-#!/usr/bin/env python3
-"""StatsBomb 360 match replay generator.
+"""Interactive StatsBomb 360 match replay generator.
 
-This script downloads StatsBomb open data (events and 360 freeze frames)
-for a single match and builds an interactive Plotly playback that can be
-used to visually replay the match phase by phase. The resulting HTML
-contains a slider-driven animation of the players on a full pitch,
-annotated with event metadata, possession changes, ball carrier details,
-and a rich set of shot-related insights.
-
-Alongside the visual output the script caches the raw data locally and
-stores tidy JSON representations of the processed events and freeze frame
-snapshots, making it easier to re-use the data for future analysis (for
-example, Markov decision process modelling).
+This script downloads StatsBomb open-data assets, caches them locally, and
+turns freeze-frame events into an interactive Plotly animation that can be
+saved as a standalone HTML file. The output keeps the pitch orientation
+consistent, renders every player as a coloured dot, highlights the ball
+carrier, and surfaces contextual details such as possession changes, goals,
+and shot quality. Alongside the visualisation, the processed freeze-frame
+stream is exported to JSON so it can seed future analytical workflows such as
+Markov decision process modelling.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
-import math
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
-try:
-    import plotly.graph_objects as go
-    from plotly.subplots import make_subplots
-except ModuleNotFoundError:  # pragma: no cover - handled at runtime
-    go = None
-    make_subplots = None
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import requests
+from requests import Response
 
-DATA_REPO_URL = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
-GITHUB_API_THREE_SIXTY = (
-    "https://api.github.com/repos/statsbomb/open-data/contents/data/three-sixty"
-)
+STATS_BOMB_BASE = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
+CACHE_DIR = Path("statsbomb_cache")
 
 PITCH_LENGTH = 120.0
 PITCH_WIDTH = 80.0
 
+HOME_COLOUR = "#1f77b4"
+AWAY_COLOUR = "#ff4136"
+BALL_COLOUR = "#f1c40f"
+TIMELINE_NEUTRAL = "#bbbbbb"
 
-@dataclass
-class TeamInfo:
-    team_id: int
-    name: str
-    side: str  # "home" or "away"
-
-
-@dataclass
-class PlayerInfo:
-    player_id: int
-    name: str
-    jersey_number: Optional[int]
-    team_id: int
-    team_name: str
-    side: str
+GOAL_OUTCOMES = {"Goal"}
+ON_TARGET_OUTCOMES = {"Goal", "Saved", "Saved To Post"}
 
 
 @dataclass
-class ShotRecord:
-    minute: int
-    second: int
-    x: Optional[float]
-    y: Optional[float]
-    xg: float
-    outcome: str
-    goal: bool
-    team_side: str
+class MatchSummary:
+    """Metadata describing a match that exposes StatsBomb 360 data."""
+
+    competition_id: int
+    competition_name: str
+    season_id: int
+    season_name: str
+    match_id: int
+    match_date: str
+    home_team_id: int
+    home_team_name: str
+    away_team_id: int
+    away_team_name: str
+    freeze_frame_events: int
 
 
-@dataclass
-class EventRecord:
-    index: int
-    event_uuid: str
-    minute: int
-    second: int
-    timestamp: str
-    team_id: Optional[int]
-    team_name: Optional[str]
-    player_id: Optional[int]
-    player_name: Optional[str]
-    event_type: str
-    detail: Optional[str]
-    outcome: Optional[str]
-    possession_team_id: Optional[int]
-    possession_team_name: Optional[str]
-    possession_number: Optional[int]
-    possession_change: bool
-    possession_from: Optional[int]
-    possession_to: Optional[int]
-    location: Tuple[Optional[float], Optional[float]]
-    end_location: Tuple[Optional[float], Optional[float]]
-    carry_end_location: Tuple[Optional[float], Optional[float]]
-    shot_end_location: Tuple[Optional[float], Optional[float]]
-    shot_xg: float
-    shot_outcome: Optional[str]
-    is_goal: bool
-    score_home: int
-    score_away: int
-    shots_home: int
-    shots_away: int
-    shots_on_target_home: int
-    shots_on_target_away: int
-    xg_home: float
-    xg_away: float
-    period: int
-    visible_area: Optional[List[float]]
 
-    @property
-    def match_time_minutes(self) -> float:
-        return self.minute + self.second / 60.0
+def fetch_statsbomb(path: str, allow_missing: bool = False) -> Optional[Iterable]:
+    """Download and cache a JSON document from the StatsBomb open data set."""
 
-    @property
-    def match_time_seconds(self) -> float:
-        return self.minute * 60.0 + self.second
+    cache_path = CACHE_DIR / path
+    if cache_path.exists():
+        with cache_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    url = f"{STATS_BOMB_BASE}/{path}"
+    response: Response = requests.get(url, timeout=30)
+    if response.status_code == 404:
+        if allow_missing:
+            return None
+        response.raise_for_status()
+    response.raise_for_status()
+
+    data = response.json()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with cache_path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle)
+    return data
 
 
-@dataclass
-class FreezeFrameRecord:
-    event_uuid: str
-    player_id: Optional[int]
-    player_name: Optional[str]
-    team_id: Optional[int]
-    team_name: Optional[str]
-    side: Optional[str]
-    jersey_number: Optional[int]
-    x: Optional[float]
-    y: Optional[float]
-    teammate: bool
-    actor: bool
-    keeper: bool
+def load_competitions() -> List[dict]:
+    competitions = fetch_statsbomb("competitions.json")
+    if competitions is None:
+        raise RuntimeError("Unable to download competitions list from StatsBomb.")
+    return list(competitions)
 
 
-class DataManager:
-    """Download and cache StatsBomb open data."""
-
-    def __init__(self, base_dir: Path) -> None:
-        self.base_dir = base_dir
-        self.raw_dir = self.base_dir / "raw"
-        self.matches_dir = self.raw_dir / "matches"
-        self.events_dir = self.raw_dir / "events"
-        self.lineups_dir = self.raw_dir / "lineups"
-        self.three_sixty_dir = self.raw_dir / "three_sixty"
-        for directory in (
-            self.base_dir,
-            self.raw_dir,
-            self.matches_dir,
-            self.events_dir,
-            self.lineups_dir,
-            self.three_sixty_dir,
-        ):
-            directory.mkdir(parents=True, exist_ok=True)
-
-    def _fetch_json(self, url: str, cache_path: Path) -> List[dict]:
-        if cache_path.exists():
-            with cache_path.open("r", encoding="utf-8") as f:
-                return json.load(f)
-        request = urllib.request.Request(url, headers={"User-Agent": "statsbomb-replay"})
-        try:
-            with urllib.request.urlopen(request) as response:
-                payload = response.read().decode("utf-8")
-        except urllib.error.HTTPError as exc:  # pragma: no cover - network
-            raise RuntimeError(f"Failed to fetch {url}: {exc}") from exc
-        cache_path.write_text(payload, encoding="utf-8")
-        return json.loads(payload)
-
-    def get_competitions(self) -> List[dict]:
-        url = f"{DATA_REPO_URL}/competitions.json"
-        cache_path = self.raw_dir / "competitions.json"
-        return self._fetch_json(url, cache_path)
-
-    def get_matches(self, competition_id: int, season_id: int) -> List[dict]:
-        url = f"{DATA_REPO_URL}/matches/{competition_id}/{season_id}.json"
-        cache_path = self.matches_dir / f"{competition_id}_{season_id}.json"
-        return self._fetch_json(url, cache_path)
-
-    def get_events(self, match_id: int) -> List[dict]:
-        url = f"{DATA_REPO_URL}/events/{match_id}.json"
-        cache_path = self.events_dir / f"{match_id}.json"
-        return self._fetch_json(url, cache_path)
-
-    def get_three_sixty(self, match_id: int) -> List[dict]:
-        url = f"{DATA_REPO_URL}/three-sixty/{match_id}.json"
-        cache_path = self.three_sixty_dir / f"{match_id}.json"
-        return self._fetch_json(url, cache_path)
-
-    def get_lineups(self, match_id: int) -> List[dict]:
-        url = f"{DATA_REPO_URL}/lineups/{match_id}.json"
-        cache_path = self.lineups_dir / f"{match_id}.json"
-        return self._fetch_json(url, cache_path)
-
-    def list_three_sixty_match_ids(self) -> List[int]:
-        request = urllib.request.Request(
-            GITHUB_API_THREE_SIXTY,
-            headers={"User-Agent": "statsbomb-replay"},
-        )
-        try:
-            with urllib.request.urlopen(request) as response:
-                payload = response.read().decode("utf-8")
-        except urllib.error.HTTPError as exc:  # pragma: no cover - network
-            raise RuntimeError(f"Failed to list 360 matches: {exc}") from exc
-        listing = json.loads(payload)
-        match_ids: List[int] = []
-        for item in listing:
-            name = item.get("name", "")
-            if name.endswith(".json"):
-                try:
-                    match_ids.append(int(name.split(".")[0]))
-                except ValueError:
-                    continue
-        return match_ids
-
-    def save_processed_dataset(
-        self,
-        match_id: int,
-        events: List[EventRecord],
-        freeze_frames: List[FreezeFrameRecord],
-    ) -> None:
-        processed_dir = self.base_dir / "processed"
-        processed_dir.mkdir(parents=True, exist_ok=True)
-        events_payload = [event.__dict__ for event in events]
-        freeze_payload = [frame.__dict__ for frame in freeze_frames]
-        (processed_dir / f"{match_id}_events.json").write_text(
-            json.dumps(events_payload, indent=2),
-            encoding="utf-8",
-        )
-        (processed_dir / f"{match_id}_freeze_frames.json").write_text(
-            json.dumps(freeze_payload, indent=2),
-            encoding="utf-8",
-        )
+def load_matches(competition_id: int, season_id: int) -> List[dict]:
+    matches = fetch_statsbomb(f"matches/{competition_id}/{season_id}.json")
+    return list(matches or [])
 
 
-def build_team_directory(match_info: dict) -> Dict[int, TeamInfo]:
-    home = match_info.get("home_team") or {}
-    away = match_info.get("away_team") or {}
-    directory: Dict[int, TeamInfo] = {}
-    if "home_team_id" in home:
-        directory[int(home["home_team_id"])] = TeamInfo(
-            team_id=int(home["home_team_id"]),
-            name=home.get("home_team_name"),
-            side="home",
-        )
-    if "away_team_id" in away:
-        directory[int(away["away_team_id"])] = TeamInfo(
-            team_id=int(away["away_team_id"]),
-            name=away.get("away_team_name"),
-            side="away",
-        )
-    return directory
+def load_events(match_id: int) -> List[dict]:
+    events = fetch_statsbomb(f"events/{match_id}.json")
+    return list(events or [])
 
 
-def build_player_directory(lineups: List[dict], teams: Dict[int, TeamInfo]) -> Dict[int, PlayerInfo]:
-    directory: Dict[int, PlayerInfo] = {}
-    for team_entry in lineups:
-        team_id = team_entry.get("team_id")
-        team_info = teams.get(team_id)
-        for player in team_entry.get("lineup", []):
-            player_id = player.get("player_id")
-            directory[player_id] = PlayerInfo(
-                player_id=player_id,
-                name=player.get("player_name"),
-                jersey_number=player.get("jersey_number"),
-                team_id=team_id,
-                team_name=team_info.name if team_info else None,
-                side=team_info.side if team_info else None,
-            )
-    return directory
+def load_freeze_frames(match_id: int) -> Dict[str, List[dict]]:
+    frames = fetch_statsbomb(f"three-sixty/{match_id}.json", allow_missing=True)
+    if not frames:
+        return {}
 
-
-def normalise_location(value: Optional[Iterable[Optional[float]]]) -> Tuple[Optional[float], Optional[float]]:
-    if not value:
-        return (None, None)
-    coords = list(value)
-    if len(coords) < 2:
-        coords += [None] * (2 - len(coords))
-    return (coords[0], coords[1])
-
-
-def orient_location(
-    location: Tuple[Optional[float], Optional[float]], flip: bool
-) -> Tuple[Optional[float], Optional[float]]:
-    if not flip:
-        return location
-    x, y = location
-    oriented_x = PITCH_LENGTH - x if x is not None else None
-    oriented_y = PITCH_WIDTH - y if y is not None else None
-    return (oriented_x, oriented_y)
-
-
-def orient_visible_area(
-    visible_area: Optional[List[float]], flip: bool
-) -> Optional[List[float]]:
-    if not visible_area or not flip:
-        return visible_area
-    oriented: List[float] = []
-    for idx, value in enumerate(visible_area):
-        if value is None:
-            oriented.append(value)
-            continue
-        if idx % 2 == 0:
-            oriented.append(PITCH_LENGTH - value)
-        else:
-            oriented.append(PITCH_WIDTH - value)
-    return oriented
-
-
-def infer_home_orientation(
-    freeze_by_event: Dict[str, dict], players: Dict[int, PlayerInfo]
-) -> bool:
-    """Return True if the home team already occupies the left side of the pitch."""
-
-    for freeze_entry in freeze_by_event.values():
-        freeze_frame = freeze_entry.get("freeze_frame") or []
-        if not freeze_frame:
-            continue
-        home_samples: List[float] = []
-        away_samples: List[float] = []
-        for player in freeze_frame:
-            player_info = player.get("player") or {}
-            player_id = player_info.get("id")
-            if player_id is None:
-                continue
-            info = players.get(player_id)
-            if info is None:
-                continue
-            location = player.get("location") or []
-            if len(location) < 2 or location[0] is None:
-                continue
-            if info.side == "home":
-                home_samples.append(float(location[0]))
-            elif info.side == "away":
-                away_samples.append(float(location[0]))
-        if home_samples and away_samples:
-            home_mean = sum(home_samples) / len(home_samples)
-            away_mean = sum(away_samples) / len(away_samples)
-            return home_mean <= away_mean
-    return True
-
-
-def compute_event_detail(event: dict) -> Tuple[Optional[str], Optional[str]]:
-    event_type = event.get("type", {}).get("name")
-    detail = None
-    outcome = None
-    if event_type == "Pass":
-        pass_info = event.get("pass", {})
-        recipient = pass_info.get("recipient", {}).get("name")
-        height = pass_info.get("height", {}).get("name")
-        detail = ", ".join(
-            [
-                part
-                for part in (
-                    f"to {recipient}" if recipient else None,
-                    pass_info.get("body_part", {}).get("name"),
-                    height,
-                )
-                if part
-            ]
-        ) or None
-        outcome = pass_info.get("outcome", {}).get("name")
-    elif event_type == "Carry":
-        carry_info = event.get("carry", {})
-        detail = (
-            f"to {carry_info.get('end_location')}" if carry_info.get("end_location") else None
-        )
-    elif event_type == "Dribble":
-        detail = event.get("dribble", {}).get("outcome", {}).get("name")
-    elif event_type == "Shot":
-        shot_info = event.get("shot", {})
-        outcome = shot_info.get("outcome", {}).get("name")
-        technique = shot_info.get("technique", {}).get("name")
-        body = shot_info.get("body_part", {}).get("name")
-        detail = ", ".join([part for part in (technique, body) if part]) or None
-    elif event_type == "Pressure":
-        detail = "Counterpress" if event.get("counterpress") else None
-    elif event_type == "Ball Receipt*":
-        outcome = event.get("ball_receipt", {}).get("outcome", {}).get("name")
-    elif event_type == "Foul Won":
-        detail = "Defensive" if event.get("foul_won", {}).get("defensive") else None
-    elif event_type == "Foul Committed":
-        detail = event.get("foul_committed", {}).get("type", {}).get("name")
-    elif event_type == "Substitution":
-        sub = event.get("substitution", {})
-        detail = sub.get("replacement", {}).get("name")
-    return detail, outcome
-
-
-def process_events(
-    raw_events: List[dict],
-    freeze_by_event: Dict[str, dict],
-    players: Dict[int, PlayerInfo],
-    teams: Dict[int, TeamInfo],
-    flip_orientation: bool,
-) -> Tuple[List[EventRecord], List[FreezeFrameRecord], List[ShotRecord]]:
-    events: List[EventRecord] = []
-    freeze_records: List[FreezeFrameRecord] = []
-    shots: List[ShotRecord] = []
-
-    home_team_id = next(team.team_id for team in teams.values() if team.side == "home")
-    away_team_id = next(team.team_id for team in teams.values() if team.side == "away")
-
-    score_home = 0
-    score_away = 0
-    shots_home = 0
-    shots_away = 0
-    shots_on_target_home = 0
-    shots_on_target_away = 0
-    xg_home = 0.0
-    xg_away = 0.0
-    previous_possession_team: Optional[int] = None
-
-    for index, event in enumerate(raw_events):
-        event_uuid = event.get("id")
-        minute = int(event.get("minute", 0))
-        second = int(event.get("second", 0))
-        team_id = event.get("team", {}).get("id")
-        team_info = teams.get(team_id)
-        team_name = team_info.name if team_info else event.get("team", {}).get("name")
-        player_id = event.get("player", {}).get("id")
-        player_info = players.get(player_id)
-        player_name = player_info.name if player_info else event.get("player", {}).get("name")
-        event_type = event.get("type", {}).get("name") or "Unknown"
-        detail, outcome = compute_event_detail(event)
-
-        location = normalise_location(event.get("location"))
-        end_location = normalise_location(event.get("pass", {}).get("end_location"))
-        carry_end_location = normalise_location(event.get("carry", {}).get("end_location"))
-        shot_end_location = normalise_location(event.get("shot", {}).get("end_location"))
-
-        oriented_location = orient_location(location, flip_orientation)
-        oriented_end_location = orient_location(end_location, flip_orientation)
-        oriented_carry_end = orient_location(carry_end_location, flip_orientation)
-        oriented_shot_end = orient_location(shot_end_location, flip_orientation)
-
-        shot_info = event.get("shot")
-        shot_xg = float(shot_info.get("statsbomb_xg", 0.0)) if shot_info else 0.0
-        shot_outcome = shot_info.get("outcome", {}).get("name") if shot_info else None
-        is_goal = bool(shot_info and shot_outcome == "Goal")
-        if shot_info:
-            if team_id == home_team_id:
-                shots_home += 1
-                xg_home += shot_xg
-                if shot_outcome in {"Saved", "Goal", "ShotOnPost", "SavedToPost"}:
-                    shots_on_target_home += 1
-                if is_goal:
-                    score_home += 1
-            elif team_id == away_team_id:
-                shots_away += 1
-                xg_away += shot_xg
-                if shot_outcome in {"Saved", "Goal", "ShotOnPost", "SavedToPost"}:
-                    shots_on_target_away += 1
-                if is_goal:
-                    score_away += 1
-            shots.append(
-                ShotRecord(
-                    minute=minute,
-                    second=second,
-                    x=oriented_location[0],
-                    y=oriented_location[1],
-                    xg=shot_xg,
-                    outcome=shot_outcome or "Unknown",
-                    goal=is_goal,
-                    team_side=team_info.side if team_info else "",
-                )
-            )
-
-        possession_team_id = event.get("possession_team", {}).get("id")
-        possession_team_name = event.get("possession_team", {}).get("name")
-        if possession_team_id is None and team_id is not None:
-            possession_team_id = team_id
-            possession_team_name = team_name
-        possession_change = False
-        possession_from = previous_possession_team
-        possession_to = possession_team_id
-        if previous_possession_team != possession_team_id:
-            possession_change = previous_possession_team is not None
-            previous_possession_team = possession_team_id
-
-        raw_visible_area = freeze_by_event.get(event_uuid, {}).get("visible_area")
-        visible_area = orient_visible_area(raw_visible_area, flip_orientation)
-
-        record = EventRecord(
-            index=index,
-            event_uuid=event_uuid,
-            minute=minute,
-            second=second,
-            timestamp=event.get("timestamp"),
-            team_id=team_id,
-            team_name=team_name,
-            player_id=player_id,
-            player_name=player_name,
-            event_type=event_type,
-            detail=detail,
-            outcome=outcome,
-            possession_team_id=possession_team_id,
-            possession_team_name=possession_team_name,
-            possession_number=event.get("possession"),
-            possession_change=possession_change,
-            possession_from=possession_from,
-            possession_to=possession_to,
-            location=oriented_location,
-            end_location=oriented_end_location,
-            carry_end_location=oriented_carry_end,
-            shot_end_location=oriented_shot_end,
-            shot_xg=shot_xg,
-            shot_outcome=shot_outcome,
-            is_goal=is_goal,
-            score_home=score_home,
-            score_away=score_away,
-            shots_home=shots_home,
-            shots_away=shots_away,
-            shots_on_target_home=shots_on_target_home,
-            shots_on_target_away=shots_on_target_away,
-            xg_home=xg_home,
-            xg_away=xg_away,
-            period=int(event.get("period", 1)),
-            visible_area=visible_area,
-        )
-        events.append(record)
-
-        freeze_data = freeze_by_event.get(event_uuid, {})
-        for player in freeze_data.get("freeze_frame", []) or []:
-            player_entry = player.get("player") or {}
-            player_id_ff = player_entry.get("id")
-            info = players.get(player_id_ff)
-            raw_location = player.get("location") or [None, None]
-            location = orient_location((raw_location[0], raw_location[1]), flip_orientation)
-            freeze_records.append(
-                FreezeFrameRecord(
-                    event_uuid=event_uuid,
-                    player_id=player_id_ff,
-                    player_name=player_entry.get("name"),
-                    team_id=info.team_id if info else None,
-                    team_name=info.team_name if info else None,
-                    side=info.side if info else None,
-                    jersey_number=info.jersey_number if info else None,
-                    x=location[0],
-                    y=location[1],
-                    teammate=bool(player.get("teammate")),
-                    actor=bool(player.get("actor")),
-                    keeper=bool(player.get("keeper")),
-                )
-            )
-
-    return events, freeze_records, shots
-
-
-def freeze_frames_by_event(freeze_data: List[dict]) -> Dict[str, dict]:
-    mapping: Dict[str, dict] = {}
-    for entry in freeze_data:
+    mapping: Dict[str, List[dict]] = {}
+    for entry in frames:
         event_uuid = entry.get("event_uuid")
-        if event_uuid:
-            mapping[event_uuid] = entry
+        if not event_uuid:
+            continue
+        mapping[event_uuid] = entry.get("freeze_frame", [])
     return mapping
 
 
-def build_pitch(fig: go.Figure, row: int, col: int, total_cols: int = 2) -> None:
-    axis_index = (row - 1) * total_cols + col
-    scaleanchor = "x" if axis_index == 1 else f"x{axis_index}"
-    fig.update_xaxes(range=[0, 120], showgrid=False, zeroline=False, visible=False, row=row, col=col)
-    fig.update_yaxes(
-        range=[-5, 85],
-        showgrid=False,
-        zeroline=False,
-        visible=False,
-        scaleanchor=scaleanchor,
-        scaleratio=1,
-        row=row,
-        col=col,
-    )
-    fig.add_shape(
-        type="rect",
-        x0=0,
-        y0=0,
-        x1=120,
-        y1=80,
-        line=dict(color="white", width=2),
-        row=row,
-        col=col,
-    )
-    fig.add_shape(
-        type="line",
-        x0=60,
-        y0=0,
-        x1=60,
-        y1=80,
-        line=dict(color="white", width=2),
-        row=row,
-        col=col,
-    )
-    fig.add_shape(
-        type="circle",
-        x0=60 - 9.15,
-        y0=40 - 9.15,
-        x1=60 + 9.15,
-        y1=40 + 9.15,
-        line=dict(color="white", width=2),
-        row=row,
-        col=col,
-    )
-    fig.add_shape(
-        type="circle",
-        x0=60 - 0.5,
-        y0=40 - 0.5,
-        x1=60 + 0.5,
-        y1=40 + 0.5,
-        fillcolor="white",
-        line=dict(color="white", width=1),
-        row=row,
-        col=col,
-    )
-    for side_start in (0, 120):
-        penalty_x0 = 0 if side_start == 0 else 120 - 18
-        penalty_x1 = 18 if side_start == 0 else 120
-        six_x0 = 0 if side_start == 0 else 120 - 6
-        six_x1 = 6 if side_start == 0 else 120
-        spot_x = 11 if side_start == 0 else 120 - 11
-        fig.add_shape(
-            type="rect",
-            x0=penalty_x0,
-            y0=18,
-            x1=penalty_x1,
-            y1=62,
-            line=dict(color="white", width=2),
-            row=row,
-            col=col,
-        )
-        fig.add_shape(
-            type="rect",
-            x0=six_x0,
-            y0=30,
-            x1=six_x1,
-            y1=50,
-            line=dict(color="white", width=2),
-            row=row,
-            col=col,
-        )
-        fig.add_shape(
-            type="circle",
-            x0=spot_x - 0.5,
-            y0=40 - 0.5,
-            x1=spot_x + 0.5,
-            y1=40 + 0.5,
-            fillcolor="white",
-            line=dict(color="white", width=1),
-            row=row,
-            col=col,
+def load_lineups(match_id: int) -> Dict[int, int]:
+    """Return a mapping of player_id -> team_id for the selected match."""
+
+    lineups = fetch_statsbomb(f"lineups/{match_id}.json")
+    if not lineups:
+        raise RuntimeError(
+            "Lineups data is required to map players to teams but was not available."
         )
 
-
-def timeline_marker_style(event: EventRecord) -> Tuple[str, float, str]:
-    if event.is_goal:
-        return "#ffd700", 16.0, "star"
-    if event.event_type == "Shot":
-        return "#ff7f0e", 12.0, "triangle-up"
-    if event.possession_change:
-        return "#f0f0f0", 12.0, "x"
-    if event.event_type in {"Foul Won", "Foul Committed"}:
-        return "#bcbd22", 10.0, "square"
-    if event.event_type in {"Pressure", "Duel", "Dribble"}:
-        return "#17becf", 10.0, "diamond"
-    return "#1f77b4", 8.0, "circle"
+    mapping: Dict[int, int] = {}
+    for team in lineups:
+        team_id = int(team.get("team_id"))
+        for player in team.get("lineup", []):
+            player_id = player.get("player_id")
+            if player_id is None:
+                continue
+            mapping[int(player_id)] = team_id
+    return mapping
 
 
-def build_event_summary(event: EventRecord, teams: Dict[int, TeamInfo]) -> str:
-    time_str = f"{event.minute:02d}:{event.second:02d}"
-    team_name = event.team_name or (
-        teams[event.team_id].name if event.team_id in teams else "Unknown"
-    )
-    player_name = event.player_name or "Unknown"
-    detail = f" ({event.detail})" if event.detail else ""
-    shot_extension = ""
-    if event.event_type == "Shot":
-        shot_extension = f" - xG {event.shot_xg:.2f} ({event.shot_outcome})"
-    possession_change = ""
-    if event.possession_change:
-        from_name = teams[event.possession_from].name if event.possession_from in teams else "Unknown"
-        to_name = teams[event.possession_to].name if event.possession_to in teams else "Unknown"
-        possession_change = f"\nPossession: {from_name} ➜ {to_name}"
-    goal_marker = " ⚽" if event.is_goal else ""
-    return (
-        f"{time_str} — {team_name} — {player_name}\n"
-        f"{event.event_type}{detail}{shot_extension}{goal_marker}{possession_change}"
-    )
+def discover_three_sixty_matches(
+    *,
+    competition_filter: Optional[int] = None,
+    season_filter: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> List[MatchSummary]:
+    """Return matches that expose StatsBomb 360 freeze frames."""
+
+    summaries: List[MatchSummary] = []
+    for competition in load_competitions():
+        comp_id = int(competition["competition_id"])
+        season_id = int(competition["season_id"])
+        if competition_filter is not None and comp_id != competition_filter:
+            continue
+        if season_filter is not None and season_id != season_filter:
+            continue
+
+        for match in load_matches(comp_id, season_id):
+            match_id = int(match["match_id"])
+            freeze_frames = fetch_statsbomb(
+                f"three-sixty/{match_id}.json", allow_missing=True
+            )
+            if not freeze_frames:
+                continue
+
+            freeze_event_count = sum(
+                1 for frame in freeze_frames if frame.get("freeze_frame")
+            )
+            summaries.append(
+                MatchSummary(
+                    competition_id=comp_id,
+                    competition_name=competition.get("competition_name", ""),
+                    season_id=season_id,
+                    season_name=competition.get("season_name", ""),
+                    match_id=match_id,
+                    match_date=match.get("match_date", ""),
+                    home_team_id=int(match.get("home_team", {}).get("home_team_id", 0)),
+                    home_team_name=match.get("home_team", {}).get("home_team_name", ""),
+                    away_team_id=int(match.get("away_team", {}).get("away_team_id", 0)),
+                    away_team_name=match.get("away_team", {}).get("away_team_name", ""),
+                    freeze_frame_events=freeze_event_count,
+                )
+            )
+            if limit and len(summaries) >= limit:
+                return summaries
+    return summaries
 
 
-def build_scoreboard_text(event: EventRecord, teams: Dict[int, TeamInfo]) -> str:
-    home_team = next(team for team in teams.values() if team.side == "home")
-    away_team = next(team for team in teams.values() if team.side == "away")
-    possession_name = event.possession_team_name or (
-        teams[event.possession_team_id].name if event.possession_team_id in teams else "N/A"
-    )
-    lines = [
-        f"<b>{home_team.name}</b> {event.score_home} - {event.score_away} <b>{away_team.name}</b>",
-        f"Possession: {possession_name}",
-        f"Shots (on target): {event.shots_home} ({event.shots_on_target_home}) | {event.shots_away} ({event.shots_on_target_away})",
-        f"xG: {event.xg_home:.2f} | {event.xg_away:.2f}",
-    ]
-    if event.event_type == "Shot":
-        lines.append(
-            f"Latest shot: {event.player_name or 'Unknown'} — xG {event.shot_xg:.2f} ({event.shot_outcome})"
-        )
-    return "<br>".join(lines)
+def format_clock(minute: int, second: int) -> str:
+    return f"{int(minute):02d}:{int(second):02d}"
 
 
-def split_freeze_players(
-    freeze_entry: List[FreezeFrameRecord],
-    home_color: str,
-    away_color: str,
-) -> Tuple[go.Scatter, go.Scatter]:
-    home_x: List[Optional[float]] = []
-    home_y: List[Optional[float]] = []
-    home_numbers: List[str] = []
+def describe_event(event: dict) -> str:
+    minute = int(event.get("minute", 0))
+    second = int(event.get("second", 0))
+    player_name = event.get("player", {}).get("name") or "Unknown player"
+    event_type = event.get("type", {}).get("name") or "Action"
+    team_name = event.get("possession_team", {}).get("name") or "Unknown team"
+
+    details = ""
+    if event_type == "Shot":
+        shot = event.get("shot", {})
+        outcome = shot.get("outcome", {}).get("name")
+        xg = shot.get("statsbomb_xg")
+        if outcome:
+            details = f" ({outcome})"
+        if xg:
+            details += f" xG={float(xg):.2f}"
+    elif event_type == "Pass":
+        passed = event.get("pass", {})
+        if passed.get("goal_assist"):
+            details = " (assist)"
+        elif passed.get("shot_assist"):
+            details = " (shot assist)"
+    elif event_type == "Foul Won":
+        details = " (foul won)"
+
+    return f"{format_clock(minute, second)} — {team_name}: {player_name} {event_type}{details}"
+
+
+def apply_orientation(value: Sequence[float], flip: bool) -> Tuple[Optional[float], Optional[float]]:
+    if not value or len(value) < 2:
+        return None, None
+    x, y = value[0], value[1]
+    if x is None or y is None:
+        return None, None
+    x = float(x)
+    y = float(y)
+    if flip:
+        x = PITCH_LENGTH - x
+    return x, y
+
+
+def determine_orientation(
+    freeze_frames: Dict[str, List[dict]],
+    player_to_team: Dict[int, int],
+    home_team_id: int,
+) -> bool:
+    """Determine if coordinates need flipping to keep the home team on the left."""
+
+    for frame in freeze_frames.values():
+        home_x: List[float] = []
+        away_x: List[float] = []
+        for player in frame:
+            player_info = player.get("player", {})
+            player_id = player_info.get("id") or player_info.get("player_id")
+            location = player.get("location")
+            if player_id is None or not location:
+                continue
+            team_id = player_to_team.get(int(player_id))
+            if team_id is None:
+                continue
+            x_value = float(location[0])
+            if team_id == home_team_id:
+                home_x.append(x_value)
+            else:
+                away_x.append(x_value)
+        if home_x and away_x:
+            home_avg = sum(home_x) / len(home_x)
+            away_avg = sum(away_x) / len(away_x)
+            return home_avg > away_avg
+    return False
+
+
+def build_timeline_data(
+    events: List[dict],
+    freeze_frames: Dict[str, List[dict]],
+) -> List[dict]:
+    return [event for event in events if event.get("id") in freeze_frames]
+
+
+def compute_score_update(
+    event: dict,
+    home_team_id: int,
+    score_home: int,
+    score_away: int,
+) -> Tuple[int, int]:
+    if event.get("type", {}).get("name") != "Shot":
+        return score_home, score_away
+    shot = event.get("shot", {})
+    outcome = shot.get("outcome", {}).get("name")
+    if outcome not in GOAL_OUTCOMES:
+        return score_home, score_away
+    team_id = event.get("team", {}).get("id")
+    if team_id == home_team_id:
+        return score_home + 1, score_away
+    return score_home, score_away + 1
+
+
+def update_shot_metrics(
+    event: dict,
+    shots: Dict[int, int],
+    shots_on_target: Dict[int, int],
+    xg_totals: Dict[int, float],
+) -> None:
+    if event.get("type", {}).get("name") != "Shot":
+        return
+    team_id = event.get("team", {}).get("id")
+    if team_id is None:
+        return
+    shots[team_id] = shots.get(team_id, 0) + 1
+    shot = event.get("shot", {})
+    outcome = shot.get("outcome", {}).get("name")
+    if outcome in ON_TARGET_OUTCOMES:
+        shots_on_target[team_id] = shots_on_target.get(team_id, 0) + 1
+    xg = shot.get("statsbomb_xg")
+    if xg is not None:
+        xg_totals[team_id] = xg_totals.get(team_id, 0.0) + float(xg)
+
+
+def extract_positions(
+    freeze_frame: List[dict],
+    player_to_team: Dict[int, int],
+    home_team_id: int,
+    flip: bool,
+    ball_carrier_id: Optional[int],
+) -> Tuple[List[float], List[float], List[str], List[float], List[float], List[float], List[str], List[float]]:
+    """Return home/away player coordinates and marker sizes."""
+
+    home_x: List[float] = []
+    home_y: List[float] = []
+    home_labels: List[str] = []
     home_sizes: List[float] = []
-    home_line_colors: List[str] = []
-    home_line_widths: List[float] = []
-    home_hover: List[str] = []
-    home_symbols: List[str] = []
 
-    away_x: List[Optional[float]] = []
-    away_y: List[Optional[float]] = []
-    away_numbers: List[str] = []
+    away_x: List[float] = []
+    away_y: List[float] = []
+    away_labels: List[str] = []
     away_sizes: List[float] = []
-    away_line_colors: List[str] = []
-    away_line_widths: List[float] = []
-    away_hover: List[str] = []
-    away_symbols: List[str] = []
 
-    for player in freeze_entry:
-        text = player.player_name or "Unknown"
-        if player.side == "home":
-            home_x.append(player.x)
-            home_y.append(player.y)
-            label = text
-            if player.keeper:
-                label = f"{label} (GK)"
-            jersey = str(player.jersey_number) if player.jersey_number is not None else ""
-            if player.actor and not jersey:
-                jersey = "★"
-            if not jersey and player.player_name:
-                jersey = player.player_name.split()[-1][:2].upper()
-            home_numbers.append(jersey)
-            home_hover.append(label)
-            size = 22 if player.actor else 16
-            line_color = "#ffd700" if player.actor else "white"
+    for player in freeze_frame:
+        player_info = player.get("player", {})
+        player_id = player_info.get("id") or player_info.get("player_id")
+        if player_id is None:
+            continue
+        location = player.get("location")
+        x, y = apply_orientation(location or (), flip)
+        if x is None or y is None:
+            continue
+        team_id = player_to_team.get(int(player_id))
+        if team_id is None:
+            continue
+        label = player_info.get("name") or "Unknown"
+        size = 16.0 if ball_carrier_id is not None and int(player_id) == ball_carrier_id else 11.0
+        if team_id == home_team_id:
+            home_x.append(x)
+            home_y.append(y)
+            home_labels.append(label)
             home_sizes.append(size)
-            home_line_colors.append(line_color)
-            home_line_widths.append(3 if player.actor else 1.5)
-            symbol = "star" if player.actor else ("hexagon" if player.keeper else "circle")
-            home_symbols.append(symbol)
-        elif player.side == "away":
-            away_x.append(player.x)
-            away_y.append(player.y)
-            label = text
-            if player.keeper:
-                label = f"{label} (GK)"
-            jersey = str(player.jersey_number) if player.jersey_number is not None else ""
-            if player.actor and not jersey:
-                jersey = "★"
-            if not jersey and player.player_name:
-                jersey = player.player_name.split()[-1][:2].upper()
-            away_numbers.append(jersey)
-            away_hover.append(label)
-            size = 22 if player.actor else 16
-            line_color = "#ffd700" if player.actor else "white"
-            away_sizes.append(size)
-            away_line_colors.append(line_color)
-            away_line_widths.append(3 if player.actor else 1.5)
-            symbol = "star" if player.actor else ("hexagon" if player.keeper else "circle")
-            away_symbols.append(symbol)
-
-    home_trace = go.Scatter(
-        x=home_x,
-        y=home_y,
-        mode="markers+text",
-        marker=dict(
-            color=home_color,
-            size=home_sizes,
-            symbol=home_symbols if home_symbols else "circle",
-            line=dict(color=home_line_colors, width=home_line_widths),
-            opacity=0.95,
-        ),
-        text=home_numbers,
-        textposition="middle center",
-        textfont=dict(color="white", size=11, family="DejaVu Sans"),
-        hovertext=home_hover,
-        name="Home team",
-        hovertemplate="%{hovertext}<extra></extra>",
-        showlegend=False,
-    )
-    away_trace = go.Scatter(
-        x=away_x,
-        y=away_y,
-        mode="markers+text",
-        marker=dict(
-            color=away_color,
-            size=away_sizes,
-            symbol=away_symbols if away_symbols else "circle",
-            line=dict(color=away_line_colors, width=away_line_widths),
-            opacity=0.95,
-        ),
-        text=away_numbers,
-        textposition="middle center",
-        textfont=dict(color="white", size=11, family="DejaVu Sans"),
-        hovertext=away_hover,
-        name="Away team",
-        hovertemplate="%{hovertext}<extra></extra>",
-        showlegend=False,
-    )
-    return home_trace, away_trace
-
-
-def infer_ball_position(event: EventRecord, freeze_entry: List[FreezeFrameRecord]) -> Tuple[Optional[float], Optional[float]]:
-    if event.location != (None, None):
-        return event.location
-    for player in freeze_entry:
-        if player.actor and player.x is not None and player.y is not None:
-            return (player.x, player.y)
-    return (None, None)
-
-
-def build_replay_figure(
-    events: List[EventRecord],
-    freeze_frames: List[FreezeFrameRecord],
-    shots: List[ShotRecord],
-    teams: Dict[int, TeamInfo],
-    match_info: dict,
-) -> go.Figure:
-    if go is None or make_subplots is None:  # pragma: no cover - runtime dependency
-        raise SystemExit(
-            "Plotly is required to build the replay figure. Install it with 'pip install plotly'."
-        )
-
-    freeze_lookup: Dict[str, List[FreezeFrameRecord]] = {}
-    for frame in freeze_frames:
-        freeze_lookup.setdefault(frame.event_uuid, []).append(frame)
-
-    events_with_frames = [event for event in events if event.event_uuid in freeze_lookup]
-    if not events_with_frames:
-        raise ValueError("No events with 360 freeze frames available for this match.")
-
-    home_color = "#1f77b4"
-    away_color = "#d62728"
-
-    timeline_x = [event.match_time_minutes for event in events_with_frames]
-    timeline_y = [0 for _ in events_with_frames]
-    timeline_colors = []
-    timeline_sizes = []
-    timeline_symbols = []
-    for event in events_with_frames:
-        color, size, symbol = timeline_marker_style(event)
-        timeline_colors.append(color)
-        timeline_sizes.append(size)
-        timeline_symbols.append(symbol)
-
-    fig = make_subplots(
-        rows=2,
-        cols=2,
-        specs=[[{"type": "scatter"}, {"type": "scatter"}], [{"type": "scatter"}, {"type": "scatter"}]],
-        column_widths=[0.7, 0.3],
-        row_heights=[0.65, 0.35],
-        vertical_spacing=0.1,
-        horizontal_spacing=0.08,
-        subplot_titles=("Pitch Replay", "Match Centre", "Event Timeline", "Shot Map"),
-    )
-
-    build_pitch(fig, row=1, col=1)
-    build_pitch(fig, row=2, col=2)
-
-    fig.add_trace(
-        go.Scatter(
-            x=timeline_x,
-            y=timeline_y,
-            mode="markers",
-            marker=dict(color=timeline_colors, size=timeline_sizes, symbol=timeline_symbols),
-            text=[build_event_summary(event, teams) for event in events_with_frames],
-            hovertemplate="%{text}<extra></extra>",
-            name="Timeline events",
-        ),
-        row=2,
-        col=1,
-    )
-    fig.update_yaxes(range=[-1, 1], visible=False, row=2, col=1)
-    max_minute = max(event.match_time_minutes for event in events_with_frames)
-    fig.update_xaxes(range=[-1, max_minute + 1], row=2, col=1, title="Minute", showgrid=False)
-
-    home_shots = [shot for shot in shots if shot.team_side == "home"]
-    away_shots = [shot for shot in shots if shot.team_side == "away"]
-    fig.add_trace(
-        go.Scatter(
-            x=[shot.x for shot in home_shots],
-            y=[shot.y for shot in home_shots],
-            mode="markers",
-            marker=dict(
-                color=home_color,
-                size=[10 + (math.sqrt(shot.xg) * 10 if shot.xg > 0 else 8) for shot in home_shots],
-                symbol=["star" if shot.goal else "circle" for shot in home_shots],
-                line=dict(color="white", width=1.5),
-                opacity=0.85,
-            ),
-            name="Home shots",
-            text=[
-                f"{shot.minute:02d}:{shot.second:02d} — xG {shot.xg:.2f} ({shot.outcome})"
-                for shot in home_shots
-            ],
-            hovertemplate="%{text}<extra></extra>",
-        ),
-        row=2,
-        col=2,
-    )
-    fig.add_trace(
-        go.Scatter(
-            x=[shot.x for shot in away_shots],
-            y=[shot.y for shot in away_shots],
-            mode="markers",
-            marker=dict(
-                color=away_color,
-                size=[10 + (math.sqrt(shot.xg) * 10 if shot.xg > 0 else 8) for shot in away_shots],
-                symbol=["star" if shot.goal else "circle" for shot in away_shots],
-                line=dict(color="white", width=1.5),
-                opacity=0.85,
-            ),
-            name="Away shots",
-            text=[
-                f"{shot.minute:02d}:{shot.second:02d} — xG {shot.xg:.2f} ({shot.outcome})"
-                for shot in away_shots
-            ],
-            hovertemplate="%{text}<extra></extra>",
-        ),
-        row=2,
-        col=2,
-    )
-
-    first_event = events_with_frames[0]
-    first_freeze = freeze_lookup[first_event.event_uuid]
-    home_players, away_players = split_freeze_players(first_freeze, home_color, away_color)
-    ball_position = infer_ball_position(first_event, first_freeze)
-
-    dynamic_trace_indices: List[int] = []
-
-    home_trace_index = len(fig.data)
-    fig.add_trace(home_players, row=1, col=1)
-    dynamic_trace_indices.append(home_trace_index)
-
-    away_trace_index = len(fig.data)
-    fig.add_trace(away_players, row=1, col=1)
-    dynamic_trace_indices.append(away_trace_index)
-
-    ball_trace_index = len(fig.data)
-    fig.add_trace(
-        go.Scatter(
-            x=[ball_position[0]] if ball_position[0] is not None else [None],
-            y=[ball_position[1]] if ball_position[1] is not None else [None],
-            mode="markers",
-            marker=dict(
-                color="#fefefe",
-                size=16,
-                line=dict(color="black", width=2),
-                symbol="circle",
-            ),
-            name="Ball",
-            hoverinfo="skip",
-            showlegend=False,
-        ),
-        row=1,
-        col=1,
-    )
-    dynamic_trace_indices.append(ball_trace_index)
-
-    event_text_index = len(fig.data)
-    fig.add_trace(
-        go.Scatter(
-            x=[60],
-            y=[-2],
-            mode="text",
-            text=[build_event_summary(first_event, teams)],
-            textfont=dict(color="white", size=14),
-            textposition="top center",
-            showlegend=False,
-            hoverinfo="none",
-        ),
-        row=1,
-        col=1,
-    )
-    dynamic_trace_indices.append(event_text_index)
-
-    scoreboard_text_index = len(fig.data)
-    fig.add_trace(
-        go.Scatter(
-            x=[0.05],
-            y=[0.9],
-            mode="text",
-            text=[build_scoreboard_text(first_event, teams)],
-            textfont=dict(color="white", size=15),
-            textposition="top left",
-            showlegend=False,
-            hoverinfo="none",
-        ),
-        row=1,
-        col=2,
-    )
-    dynamic_trace_indices.append(scoreboard_text_index)
-
-    timeline_marker_index = len(fig.data)
-    fig.add_trace(
-        go.Scatter(
-            x=[first_event.match_time_minutes],
-            y=[0],
-            mode="markers",
-            marker=dict(color="#ffff00", size=18, symbol="line-ns-open"),
-            showlegend=False,
-            hoverinfo="skip",
-        ),
-        row=2,
-        col=1,
-    )
-    dynamic_trace_indices.append(timeline_marker_index)
-
-    shot_highlight_index = len(fig.data)
-    has_initial_shot = (
-        first_event.event_type == "Shot"
-        and first_event.location != (None, None)
-        and first_event.shot_end_location != (None, None)
-    )
-    if not has_initial_shot:
-        shot_x = [None]
-        shot_y = [None]
-        shot_line_color = "rgba(0,0,0,0)"
-    else:
-        shot_x = [first_event.location[0], first_event.shot_end_location[0]]
-        shot_y = [first_event.location[1], first_event.shot_end_location[1]]
-        shot_line_color = "#ffd700" if first_event.is_goal else "#ffffaa"
-    fig.add_trace(
-        go.Scatter(
-            x=shot_x,
-            y=shot_y,
-            mode="lines+markers",
-            line=dict(color=shot_line_color, width=3, dash="dot"),
-            marker=dict(
-                color=shot_line_color,
-                size=10,
-                symbol="circle-open",
-                line=dict(color=shot_line_color, width=2),
-            ),
-            hoverinfo="skip",
-            showlegend=False,
-        ),
-        row=1,
-        col=1,
-    )
-    dynamic_trace_indices.append(shot_highlight_index)
-
-    fig.update_xaxes(range=[0, 1], visible=False, row=1, col=2)
-    fig.update_yaxes(range=[0, 1], visible=False, row=1, col=2)
-    fig.add_shape(
-        type="rect",
-        x0=0,
-        y0=0,
-        x1=1,
-        y1=1,
-        xref="x2",
-        yref="y2",
-        fillcolor="rgba(27, 67, 50, 0.85)",
-        line=dict(color="rgba(255,255,255,0.2)", width=1),
-        layer="below",
-        row=1,
-        col=2,
-    )
-
-    frames = []
-    slider_steps = []
-    for idx, event in enumerate(events_with_frames):
-        freeze_records_for_event = freeze_lookup[event.event_uuid]
-        home_trace, away_trace = split_freeze_players(
-            freeze_records_for_event, home_color, away_color
-        )
-        ball_x, ball_y = infer_ball_position(event, freeze_records_for_event)
-        has_shot = (
-            event.event_type == "Shot"
-            and event.location != (None, None)
-            and event.shot_end_location != (None, None)
-        )
-        if has_shot:
-            shot_x = [event.location[0], event.shot_end_location[0]]
-            shot_y = [event.location[1], event.shot_end_location[1]]
-            shot_line_color = "#ffd700" if event.is_goal else "#ffffaa"
         else:
-            shot_x = [None]
-            shot_y = [None]
-            shot_line_color = "rgba(0,0,0,0)"
-        frame_data = [
-            home_trace,
-            away_trace,
-            go.Scatter(
-                x=[ball_x] if ball_x is not None else [None],
-                y=[ball_y] if ball_y is not None else [None],
-                mode="markers",
-                marker=dict(
-                    color="#fefefe",
-                    size=16,
-                    line=dict(color="black", width=2),
-                    symbol="circle",
-                ),
-                showlegend=False,
-                hoverinfo="skip",
-            ),
-            go.Scatter(
-                x=[60],
-                y=[-2],
-                mode="text",
-                text=[build_event_summary(event, teams)],
-                textfont=dict(color="white", size=14),
-                textposition="top center",
-                showlegend=False,
-                hoverinfo="none",
-            ),
-            go.Scatter(
-                x=[0.05],
-                y=[0.9],
-                mode="text",
-                text=[build_scoreboard_text(event, teams)],
-                textfont=dict(color="white", size=15),
-                textposition="top left",
-                showlegend=False,
-                hoverinfo="none",
-            ),
-            go.Scatter(
-                x=[event.match_time_minutes],
-                y=[0],
-                mode="markers",
-                marker=dict(color="#ffff00", size=18, symbol="line-ns-open"),
-                showlegend=False,
-                hoverinfo="skip",
-            ),
-            go.Scatter(
-                x=shot_x,
-                y=shot_y,
-                mode="lines+markers",
-                line=dict(color=shot_line_color, width=3, dash="dot"),
-                marker=dict(
-                    color=shot_line_color,
-                    size=10,
-                    symbol="circle-open",
-                    line=dict(color=shot_line_color, width=2),
-                ),
-                showlegend=False,
-                hoverinfo="skip",
-            ),
-        ]
-        frame = go.Frame(
-            data=frame_data,
-            name=str(idx),
-            traces=dynamic_trace_indices,
+            away_x.append(x)
+            away_y.append(y)
+            away_labels.append(label)
+            away_sizes.append(size)
+    return home_x, home_y, home_labels, home_sizes, away_x, away_y, away_labels, away_sizes
+
+
+def prepare_animation_frames(
+    ordered_events: List[dict],
+    freeze_frames: Dict[str, List[dict]],
+    player_to_team: Dict[int, int],
+    home_team_id: int,
+    away_team_id: int,
+    flip: bool,
+    home_team_name: str,
+    away_team_name: str,
+) -> Tuple[List[dict], List[dict]]:
+    """Return frame metadata and timeline markers for the animation."""
+
+    frames: List[dict] = []
+    timeline_markers: List[dict] = []
+
+    score_home = 0
+    score_away = 0
+    shots: Dict[int, int] = {home_team_id: 0, away_team_id: 0}
+    shots_on_target: Dict[int, int] = {home_team_id: 0, away_team_id: 0}
+    xg_totals: Dict[int, float] = {home_team_id: 0.0, away_team_id: 0.0}
+
+    filtered_events = build_timeline_data(ordered_events, freeze_frames)
+
+    for idx, event in enumerate(filtered_events):
+        event_id = event.get("id")
+        if not event_id:
+            continue
+        freeze_frame = freeze_frames.get(event_id)
+        if not freeze_frame:
+            continue
+
+        player_info = event.get("player", {})
+        ball_carrier_id = player_info.get("id") or player_info.get("player_id")
+
+        (
+            home_x,
+            home_y,
+            home_labels,
+            home_sizes,
+            away_x,
+            away_y,
+            away_labels,
+            away_sizes,
+        ) = extract_positions(
+            freeze_frame,
+            player_to_team,
+            home_team_id,
+            flip,
+            int(ball_carrier_id) if ball_carrier_id is not None else None,
         )
-        frames.append(frame)
-        slider_steps.append(
+
+        ball_x, ball_y = apply_orientation(event.get("location") or (), flip)
+
+        score_home, score_away = compute_score_update(event, home_team_id, score_home, score_away)
+        update_shot_metrics(event, shots, shots_on_target, xg_totals)
+
+        minute = int(event.get("minute", 0))
+        second = int(event.get("second", 0))
+        time_seconds = minute * 60 + second
+        possession_team_id = event.get("possession_team", {}).get("id")
+
+        next_possession_id: Optional[int] = None
+        if idx + 1 < len(filtered_events):
+            next_possession_id = filtered_events[idx + 1].get("possession_team", {}).get("id")
+        possession_changed = (
+            possession_team_id is not None
+            and next_possession_id is not None
+            and possession_team_id != next_possession_id
+        )
+
+        event_type = event.get("type", {}).get("name", "Event")
+        description = describe_event(event)
+
+        shot = event.get("shot")
+        shot_line: Tuple[List[float], List[float]] = ([], [])
+        if shot:
+            end_location = shot.get("end_location") or []
+            end_x, end_y = apply_orientation(end_location, flip)
+            if ball_x is not None and ball_y is not None and end_x is not None and end_y is not None:
+                shot_line = ([ball_x, end_x], [ball_y, end_y])
+
+        score_text = (
+            f"<b>{home_team_name}</b> {score_home} - {score_away} <b>{away_team_name}</b>"
+        )
+        stats_text = (
+            f"Shots: {shots.get(home_team_id, 0)} - {shots.get(away_team_id, 0)}"\
+            f"<br>On target: {shots_on_target.get(home_team_id, 0)} - {shots_on_target.get(away_team_id, 0)}"\
+            f"<br>xG: {xg_totals.get(home_team_id, 0.0):.2f} - {xg_totals.get(away_team_id, 0.0):.2f}"
+        )
+
+        carrier_name = player_info.get("name") or "Unknown"
+        possession_note = " — possession lost" if possession_changed else ""
+        event_label = f"{format_clock(minute, second)} {carrier_name}: {event_type}{possession_note}"
+
+        frames.append(
             {
-                "args": [[frame.name], {"frame": {"duration": 0, "redraw": True}, "mode": "immediate"}],
-                "label": f"{event.minute:02d}:{event.second:02d} {event.event_type}",
-                "method": "animate",
+                "home_x": home_x,
+                "home_y": home_y,
+                "home_labels": home_labels,
+                "home_sizes": home_sizes,
+                "away_x": away_x,
+                "away_y": away_y,
+                "away_labels": away_labels,
+                "away_sizes": away_sizes,
+                "ball_x": [ball_x] if ball_x is not None else [],
+                "ball_y": [ball_y] if ball_y is not None else [],
+                "description": description,
+                "event_label": event_label,
+                "score_text": score_text,
+                "stats_text": stats_text,
+                "shot_line": shot_line,
+                "time_seconds": time_seconds,
+                "team_id": event.get("team", {}).get("id"),
+                "event_type": event_type,
+                "is_goal": event.get("shot", {}).get("outcome", {}).get("name") in GOAL_OUTCOMES,
+                "is_shot": event_type == "Shot",
             }
         )
 
-    fig.frames = frames
-    frame_names = [frame.name for frame in frames]
-    default_frame_duration = 260
+        timeline_markers.append(
+            {
+                "time": time_seconds,
+                "team_id": event.get("team", {}).get("id"),
+                "label": event_type,
+                "description": description,
+                "is_goal": frames[-1]["is_goal"],
+                "is_shot": frames[-1]["is_shot"],
+            }
+        )
 
-    fig.update_layout(
-        width=1320,
-        height=860,
-        showlegend=True,
-        legend=dict(bgcolor="rgba(0,0,0,0)", font=dict(color="white")),
-        plot_bgcolor="#0b6623",
-        paper_bgcolor="#123524",
-        font=dict(color="white"),
-        hovermode="closest",
-        margin=dict(l=40, r=40, t=80, b=40),
-        transition=dict(duration=default_frame_duration, easing="quad-in-out"),
-        sliders=[
+    return frames, timeline_markers
+
+
+def save_processed_stream(
+    match: MatchSummary,
+    frames: List[dict],
+    timeline_markers: List[dict],
+    output_dir: Path,
+) -> Path:
+    """Persist the processed freeze-frame stream for future analysis."""
+
+    payload = {
+        "match": {
+            "match_id": match.match_id,
+            "match_date": match.match_date,
+            "competition_id": match.competition_id,
+            "competition_name": match.competition_name,
+            "season_id": match.season_id,
+            "season_name": match.season_name,
+            "home_team_id": match.home_team_id,
+            "home_team_name": match.home_team_name,
+            "away_team_id": match.away_team_id,
+            "away_team_name": match.away_team_name,
+        },
+        "frames": frames,
+        "timeline": timeline_markers,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"match_{match.match_id}_freeze_frames.json"
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    return output_path
+
+
+def pitch_shapes() -> List[dict]:
+    """Return Plotly shape definitions for a stylised football pitch."""
+
+    shapes = [
+        {
+            "type": "rect",
+            "x0": 0,
+            "y0": 0,
+            "x1": PITCH_LENGTH,
+            "y1": PITCH_WIDTH,
+            "line": {"color": "#ffffff", "width": 2},
+        },
+        {
+            "type": "line",
+            "x0": PITCH_LENGTH / 2,
+            "y0": 0,
+            "x1": PITCH_LENGTH / 2,
+            "y1": PITCH_WIDTH,
+            "line": {"color": "#ffffff", "width": 1},
+        },
+        {
+            "type": "circle",
+            "xref": "x",
+            "yref": "y",
+            "x0": PITCH_LENGTH / 2 - 9.15,
+            "y0": PITCH_WIDTH / 2 - 9.15,
+            "x1": PITCH_LENGTH / 2 + 9.15,
+            "y1": PITCH_WIDTH / 2 + 9.15,
+            "line": {"color": "#ffffff", "width": 1},
+        },
+    ]
+
+    penalty_length = 16.5
+    penalty_width = 40.32
+    six_length = 5.5
+    six_width = 18.32
+
+    shapes.extend(
+        [
+            {
+                "type": "rect",
+                "x0": 0,
+                "y0": (PITCH_WIDTH - penalty_width) / 2,
+                "x1": penalty_length,
+                "y1": (PITCH_WIDTH + penalty_width) / 2,
+                "line": {"color": "#ffffff", "width": 1},
+            },
+            {
+                "type": "rect",
+                "x0": PITCH_LENGTH - penalty_length,
+                "y0": (PITCH_WIDTH - penalty_width) / 2,
+                "x1": PITCH_LENGTH,
+                "y1": (PITCH_WIDTH + penalty_width) / 2,
+                "line": {"color": "#ffffff", "width": 1},
+            },
+            {
+                "type": "rect",
+                "x0": 0,
+                "y0": (PITCH_WIDTH - six_width) / 2,
+                "x1": six_length,
+                "y1": (PITCH_WIDTH + six_width) / 2,
+                "line": {"color": "#ffffff", "width": 1},
+            },
+            {
+                "type": "rect",
+                "x0": PITCH_LENGTH - six_length,
+                "y0": (PITCH_WIDTH - six_width) / 2,
+                "x1": PITCH_LENGTH,
+                "y1": (PITCH_WIDTH + six_width) / 2,
+                "line": {"color": "#ffffff", "width": 1},
+            },
+        ]
+    )
+    return shapes
+
+
+def build_timeline_trace(timeline_markers: List[dict], home_team_id: int, away_team_id: int) -> go.Scatter:
+    x_values = [marker["time"] for marker in timeline_markers]
+    y_values = []
+    marker_colours = []
+    marker_symbols = []
+    marker_sizes = []
+    hover_texts = []
+
+    for marker in timeline_markers:
+        team_id = marker.get("team_id")
+        if team_id == home_team_id:
+            y_values.append(0)
+            marker_colours.append(HOME_COLOUR)
+        elif team_id == away_team_id:
+            y_values.append(1)
+            marker_colours.append(AWAY_COLOUR)
+        else:
+            y_values.append(0.5)
+            marker_colours.append(TIMELINE_NEUTRAL)
+
+        if marker.get("is_goal"):
+            marker_symbols.append("star")
+            marker_sizes.append(14)
+        elif marker.get("is_shot"):
+            marker_symbols.append("triangle-up")
+            marker_sizes.append(11)
+        else:
+            marker_symbols.append("circle")
+            marker_sizes.append(9)
+        hover_texts.append(marker.get("description", ""))
+
+    return go.Scatter(
+        x=x_values,
+        y=y_values,
+        mode="markers",
+        marker=dict(color=marker_colours, size=marker_sizes, symbol=marker_symbols),
+        hovertemplate="%{text}<extra></extra>",
+        text=hover_texts,
+        name="Event timeline",
+    )
+
+
+def make_animation(
+    match: MatchSummary,
+    frames: List[dict],
+    timeline_markers: List[dict],
+    output_path: Path,
+    playback_duration: int,
+) -> None:
+    if not frames:
+        raise RuntimeError("No freeze-frame events were found for this match.")
+
+    timeline_trace = build_timeline_trace(
+        timeline_markers, match.home_team_id, match.away_team_id
+    )
+
+    timeline_x = list(timeline_trace.x)
+    timeline_y = list(timeline_trace.y)
+    timeline_colors = list(timeline_trace.marker.color)
+    timeline_symbols = list(timeline_trace.marker.symbol)
+    base_marker_sizes = [
+        14 if marker.get("is_goal") else 11 if marker.get("is_shot") else 9
+        for marker in timeline_markers
+    ]
+
+    fig = make_subplots(
+        rows=2,
+        cols=1,
+        shared_xaxes=False,
+        vertical_spacing=0.08,
+        row_heights=[0.7, 0.3],
+        specs=[[{"type": "scatter"}], [{"type": "scatter"}]],
+    )
+
+    initial = frames[0]
+
+    home_trace = go.Scatter(
+        x=initial["home_x"],
+        y=initial["home_y"],
+        mode="markers",
+        marker=dict(color=HOME_COLOUR, size=initial["home_sizes"], line=dict(width=1, color="#ffffff")),
+        text=initial["home_labels"],
+        hovertemplate="%{text}<extra></extra>",
+        name=match.home_team_name,
+    )
+
+    away_trace = go.Scatter(
+        x=initial["away_x"],
+        y=initial["away_y"],
+        mode="markers",
+        marker=dict(color=AWAY_COLOUR, size=initial["away_sizes"], line=dict(width=1, color="#ffffff")),
+        text=initial["away_labels"],
+        hovertemplate="%{text}<extra></extra>",
+        name=match.away_team_name,
+    )
+
+    ball_trace = go.Scatter(
+        x=initial["ball_x"],
+        y=initial["ball_y"],
+        mode="markers",
+        marker=dict(color=BALL_COLOUR, size=18, symbol="circle"),
+        hoverinfo="skip",
+        name="Ball",
+    )
+
+    shot_trace = go.Scatter(
+        x=initial["shot_line"][0],
+        y=initial["shot_line"][1],
+        mode="lines",
+        line=dict(color="#ffffff", width=2, dash="dot"),
+        hoverinfo="skip",
+        name="Shot path",
+    )
+
+    fig.add_trace(home_trace, row=1, col=1)
+    fig.add_trace(away_trace, row=1, col=1)
+    fig.add_trace(ball_trace, row=1, col=1)
+    fig.add_trace(shot_trace, row=1, col=1)
+    fig.add_trace(timeline_trace, row=2, col=1)
+
+    initial_annotation_text = (
+        f"<b>{initial['event_label']}</b><br>{initial['description']}"
+    )
+    initial_annotations = [
+        dict(
+            x=1.03,
+            y=0.82,
+            xref="paper",
+            yref="paper",
+            text=initial["score_text"],
+            showarrow=False,
+            align="left",
+            font=dict(color="#ffffff", size=18),
+        ),
+        dict(
+            x=1.03,
+            y=0.48,
+            xref="paper",
+            yref="paper",
+            text=initial["stats_text"],
+            showarrow=False,
+            align="left",
+            font=dict(color="#dddddd", size=12),
+        ),
+        dict(
+            x=0,
+            y=1.08,
+            xref="paper",
+            yref="paper",
+            text=initial_annotation_text,
+            showarrow=False,
+            align="left",
+            font=dict(color="#ffffff", size=13),
+        ),
+    ]
+
+    slider_steps = []
+    animation_frames = []
+    for idx, frame in enumerate(frames):
+        step = dict(
+            method="animate",
+            label=str(idx + 1),
+            args=[[str(idx)], {"mode": "immediate", "frame": {"duration": 0, "redraw": True}}],
+        )
+        slider_steps.append(step)
+
+        annotation_text = (
+            f"<b>{frame['event_label']}</b><br>{frame['description']}"
+        )
+
+        frame_annotations = [
             dict(
-                active=0,
-                currentvalue=dict(prefix="Event: ", font=dict(color="white", size=16)),
-                pad=dict(t=30),
-                steps=slider_steps,
-                x=0.1,
-                len=0.75,
-                transition=dict(duration=200, easing="quad-in-out"),
-            )
-        ],
-        updatemenus=[
-            dict(
-                type="buttons",
-                direction="left",
-                buttons=[
-                    dict(
-                        label="⏯ Slow",
-                        method="animate",
-                        args=[
-                            frame_names,
-                            {
-                                "frame": {"duration": default_frame_duration * 2, "redraw": True},
-                                "transition": {"duration": default_frame_duration * 2, "easing": "quad-in-out"},
-                                "fromcurrent": True,
-                                "mode": "immediate",
-                            },
-                        ],
-                    ),
-                    dict(
-                        label="▶ Normal",
-                        method="animate",
-                        args=[
-                            frame_names,
-                            {
-                                "frame": {"duration": default_frame_duration, "redraw": True},
-                                "transition": {"duration": default_frame_duration, "easing": "quad-in-out"},
-                                "fromcurrent": True,
-                                "mode": "immediate",
-                            },
-                        ],
-                    ),
-                    dict(
-                        label="⏩ Fast",
-                        method="animate",
-                        args=[
-                            frame_names,
-                            {
-                                "frame": {"duration": max(120, default_frame_duration // 2), "redraw": True},
-                                "transition": {"duration": max(120, default_frame_duration // 2), "easing": "quad-in-out"},
-                                "fromcurrent": True,
-                                "mode": "immediate",
-                            },
-                        ],
-                    ),
-                    dict(
-                        label="⏸ Pause",
-                        method="animate",
-                        args=[[None], {"frame": {"duration": 0}, "mode": "immediate"}],
-                    ),
-                ],
-                pad=dict(t=30, r=10),
-                x=0.88,
-                y=1.07,
-                bgcolor="#1b4332",
-            )
-        ],
-        annotations=[
-            dict(
-                text=(
-                    f"Referee: {match_info.get('referee', {}).get('name', 'Unknown')}<br>"
-                    f"Venue: {match_info.get('stadium', {}).get('name', 'Unknown')}"
-                ),
-                x=0.82,
-                y=0.32,
+                x=1.03,
+                y=0.82,
                 xref="paper",
                 yref="paper",
+                text=frame["score_text"],
                 showarrow=False,
-                font=dict(size=12, color="white"),
+                align="left",
+                font=dict(color="#ffffff", size=18),
+            ),
+            dict(
+                x=1.03,
+                y=0.48,
+                xref="paper",
+                yref="paper",
+                text=frame["stats_text"],
+                showarrow=False,
+                align="left",
+                font=dict(color="#dddddd", size=12),
+            ),
+            dict(
+                x=0,
+                y=1.08,
+                xref="paper",
+                yref="paper",
+                text=annotation_text,
+                showarrow=False,
+                align="left",
+                font=dict(color="#ffffff", size=13),
+            ),
+        ]
+
+        highlight_sizes = []
+        for marker_idx, base_size in enumerate(base_marker_sizes):
+            if marker_idx == idx:
+                highlight_sizes.append(base_size + 4)
+            else:
+                highlight_sizes.append(base_size)
+
+        animation_frames.append(
+            go.Frame(
+                name=str(idx),
+                data=[
+                    go.Scatter(
+                        x=frame["home_x"],
+                        y=frame["home_y"],
+                        mode="markers",
+                        marker=dict(
+                            size=frame["home_sizes"],
+                            color=HOME_COLOUR,
+                            line=dict(width=1, color="#ffffff"),
+                        ),
+                        text=frame["home_labels"],
+                    ),
+                    go.Scatter(
+                        x=frame["away_x"],
+                        y=frame["away_y"],
+                        mode="markers",
+                        marker=dict(
+                            size=frame["away_sizes"],
+                            color=AWAY_COLOUR,
+                            line=dict(width=1, color="#ffffff"),
+                        ),
+                        text=frame["away_labels"],
+                    ),
+                    go.Scatter(
+                        x=frame["ball_x"],
+                        y=frame["ball_y"],
+                        mode="markers",
+                        marker=dict(color=BALL_COLOUR, size=18),
+                    ),
+                    go.Scatter(
+                        x=frame["shot_line"][0],
+                        y=frame["shot_line"][1],
+                        mode="lines",
+                    ),
+                    go.Scatter(
+                        x=timeline_x,
+                        y=timeline_y,
+                        mode="markers",
+                        marker=dict(
+                            color=timeline_colors,
+                            symbol=timeline_symbols,
+                            size=highlight_sizes,
+                        ),
+                        text=timeline_trace.text,
+                        hovertemplate=timeline_trace.hovertemplate,
+                        name=timeline_trace.name,
+                    ),
+                ],
+                layout=go.Layout(annotations=frame_annotations),
             )
+        )
+
+    fig.frames = animation_frames
+
+    fig.update_layout(
+        title=(
+            f"{match.home_team_name} vs {match.away_team_name} ({match.match_date})<br>"
+            f"{match.competition_name} {match.season_name}"
+        ),
+        paper_bgcolor="#111111",
+        plot_bgcolor="#111111",
+        width=1200,
+        height=820,
+        showlegend=False,
+        margin=dict(l=50, r=320, t=90, b=40),
+        shapes=pitch_shapes(),
+        xaxis=dict(
+            range=[0, PITCH_LENGTH],
+            showgrid=False,
+            zeroline=False,
+            showticklabels=False,
+            scaleanchor="y",
+            scaleratio=1,
+        ),
+        yaxis=dict(
+            range=[0, PITCH_WIDTH],
+            showgrid=False,
+            zeroline=False,
+            showticklabels=False,
+        ),
+        xaxis2=dict(title="Match seconds", showgrid=True, zeroline=False, color="#bbbbbb"),
+        yaxis2=dict(
+            tickmode="array",
+            tickvals=[0, 1],
+            ticktext=[match.home_team_name, match.away_team_name],
+            range=[-0.5, 1.5],
+            showgrid=False,
+            zeroline=False,
+            color="#bbbbbb",
+        ),
+        sliders=[
+            {
+                "active": 0,
+                "currentvalue": {"prefix": "Frame ", "font": {"color": "#ffffff"}},
+                "pad": {"t": 50},
+                "steps": slider_steps,
+            }
         ],
+        updatemenus=[
+            {
+                "type": "buttons",
+                "buttons": [
+                    {
+                        "label": "Play",
+                        "method": "animate",
+                        "args": [
+                            None,
+                            {
+                                "frame": {"duration": playback_duration, "redraw": True},
+                                "fromcurrent": True,
+                                "transition": {"duration": max(playback_duration // 3, 60)},
+                            },
+                        ],
+                    },
+                    {
+                        "label": "Pause",
+                        "method": "animate",
+                        "args": [[None], {"mode": "immediate", "frame": {"duration": 0, "redraw": False}}],
+                    },
+                ],
+                "direction": "left",
+                "pad": {"r": 10, "t": 50},
+                "x": 0.1,
+                "y": -0.07,
+                "bgcolor": "#222222",
+                "bordercolor": "#444444",
+                "font": {"color": "#ffffff"},
+            }
+        ],
+        annotations=initial_annotations,
     )
 
-    return fig
+    fig.update_yaxes(scaleanchor="x", scaleratio=1, row=1, col=1)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.write_html(str(output_path), include_plotlyjs="cdn", auto_play=False)
 
 
-def build_three_sixty_catalog(manager: DataManager) -> Dict[int, dict]:
-    match_ids = set(manager.list_three_sixty_match_ids())
-    competitions = manager.get_competitions()
-    catalog: Dict[int, dict] = {}
-    remaining = set(match_ids)
-    for competition in competitions:
-        competition_id = competition.get("competition_id")
-        season_id = competition.get("season_id")
-        if competition_id is None or season_id is None:
-            continue
-        matches = manager.get_matches(int(competition_id), int(season_id))
-        for match in matches:
-            match_id = match.get("match_id")
-            if match_id in remaining:
-                catalog[int(match_id)] = {
-                    "match": match,
-                    "competition": competition,
-                    "competition_id": int(competition_id),
-                    "season_id": int(season_id),
-                }
-                remaining.remove(match_id)
-        if not remaining:
-            break
-    return catalog
-
-
-def list_matches_with_three_sixty(
-    catalog: Dict[int, dict],
-    competition_id: Optional[int] = None,
-    season_id: Optional[int] = None,
-    team_query: Optional[str] = None,
-) -> None:
-    team_query_normalised = team_query.lower() if team_query else None
-    rows = []
-    for match_id, entry in catalog.items():
-        comp_id = entry["competition_id"]
-        comp_season = entry["season_id"]
-        if competition_id is not None and comp_id != competition_id:
-            continue
-        if season_id is not None and comp_season != season_id:
-            continue
-        match = entry["match"]
-        home = match.get("home_team", {}).get("home_team_name", "Unknown")
-        away = match.get("away_team", {}).get("away_team_name", "Unknown")
-        if team_query_normalised and team_query_normalised not in home.lower() and team_query_normalised not in away.lower():
-            continue
-        rows.append(
-            (
-                match_id,
-                match.get("match_date"),
-                home,
-                away,
-                match.get("competition_stage", {}).get("name"),
-                entry["competition"].get("competition_name"),
-                entry["competition"].get("season_name"),
-            )
-        )
-    if not rows:
-        print("No matches with 360 data found that match the given filters.")
-        return
-    rows.sort(key=lambda item: (item[1] or "", item[0]))
-    header = (
-        f"{'Match ID':>8}  {'Date':<12}  {'Home':<25}  {'Away':<25}  {'Stage':<15}  "
-        f"{'Competition':<25}  {'Season'}"
-    )
-    print(header)
-    print("-" * len(header))
-    for match_id, date, home, away, stage, competition_name, season_name in rows:
-        print(
-            f"{match_id:>8}  {str(date):<12}  {home:<25}  {away:<25}  {str(stage):<15}  "
-            f"{str(competition_name):<25}  {str(season_name)}"
-        )
-
-
-def parse_arguments() -> argparse.Namespace:
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Generate an interactive replay for a StatsBomb 360 match.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Create an interactive Plotly replay for StatsBomb 360 matches.",
     )
     parser.add_argument(
         "--competition-id",
         type=int,
-        help="Optional StatsBomb competition id filter when listing matches",
+        help="Limit search to a specific competition ID.",
     )
     parser.add_argument(
         "--season-id",
         type=int,
-        help="Optional StatsBomb season id filter when listing matches",
+        help="Limit search to a specific season ID.",
     )
-    parser.add_argument("--match-id", type=int, help="StatsBomb match id")
+    parser.add_argument(
+        "--match-id",
+        type=int,
+        help="Render a specific match (must expose 360 data).",
+    )
+    parser.add_argument(
+        "--max-matches",
+        type=int,
+        default=5,
+        help="Maximum matches to scan when listing options.",
+    )
     parser.add_argument(
         "--output",
         type=Path,
         default=Path("match_replay.html"),
-        help="Path to the HTML file that will contain the replay",
+        help="Destination HTML file for the replay animation.",
     )
     parser.add_argument(
-        "--data-dir",
-        type=Path,
-        default=Path("data"),
-        help="Directory where downloaded and processed data will be stored",
+        "--playback-speed",
+        type=int,
+        default=500,
+        help="Frame duration in milliseconds when playing the animation.",
     )
     parser.add_argument(
-        "--list-matches",
+        "--list",
         action="store_true",
-        help="List all matches with 360 data (optionally filtered) and exit",
-    )
-    parser.add_argument(
-        "--team",
-        type=str,
-        help="Filter listed matches by team name (case insensitive substring)",
+        help="List matches that expose 360 freeze frames and exit.",
     )
     return parser.parse_args()
 
 
-def main() -> None:
-    args = parse_arguments()
-    manager = DataManager(args.data_dir)
-    catalog = build_three_sixty_catalog(manager)
+def select_match(matches: List[MatchSummary], match_id: Optional[int]) -> MatchSummary:
+    if match_id is None:
+        if not matches:
+            raise RuntimeError(
+                "No matches with StatsBomb 360 data were found. Increase --max-matches or adjust filters."
+            )
+        return matches[0]
 
-    if args.list_matches:
-        if args.match_id:
-            print("--match-id is ignored when --list-matches is supplied.")
-        list_matches_with_three_sixty(
-            catalog,
-            competition_id=args.competition_id,
-            season_id=args.season_id,
-            team_query=args.team,
-        )
-        return
+    for summary in matches:
+        if summary.match_id == match_id:
+            return summary
 
-    if args.match_id is None:
-        raise SystemExit("--match-id is required unless --list-matches is used")
-
-    match_entry = catalog.get(args.match_id)
-    if match_entry is None:
-        raise SystemExit(
-            "Match not found among StatsBomb 360 fixtures. Run with --list-matches to discover available ids."
+    freeze_frames = load_freeze_frames(match_id)
+    if not freeze_frames:
+        raise RuntimeError(
+            f"Match {match_id} does not expose StatsBomb 360 data. Choose another fixture."
         )
 
-    match_info = match_entry["match"]
-
-    freeze_data = manager.get_three_sixty(args.match_id)
-    if not freeze_data:
-        raise SystemExit("No 360 data available for this match")
-
-    events_data = manager.get_events(args.match_id)
-    lineups = manager.get_lineups(args.match_id)
-
-    teams = build_team_directory(match_info)
-    players = build_player_directory(lineups, teams)
-    freeze_lookup = freeze_frames_by_event(freeze_data)
-    home_already_left = infer_home_orientation(freeze_lookup, players)
-    events, freeze_frames, shots = process_events(
-        events_data,
-        freeze_lookup,
-        players,
-        teams,
-        flip_orientation=not home_already_left,
+    for competition in load_competitions():
+        comp_id = int(competition["competition_id"])
+        season_id = int(competition["season_id"])
+        for match in load_matches(comp_id, season_id):
+            if int(match["match_id"]) == match_id:
+                return MatchSummary(
+                    competition_id=comp_id,
+                    competition_name=competition.get("competition_name", ""),
+                    season_id=season_id,
+                    season_name=competition.get("season_name", ""),
+                    match_id=match_id,
+                    match_date=match.get("match_date", ""),
+                    home_team_id=int(match.get("home_team", {}).get("home_team_id", 0)),
+                    home_team_name=match.get("home_team", {}).get("home_team_name", ""),
+                    away_team_id=int(match.get("away_team", {}).get("away_team_id", 0)),
+                    away_team_name=match.get("away_team", {}).get("away_team_name", ""),
+                    freeze_frame_events=sum(
+                        1 for frame in freeze_frames.values() if frame
+                    ),
+                )
+    raise RuntimeError(
+        "Unable to locate metadata for the requested match even though 360 data exists."
     )
 
-    manager.save_processed_dataset(args.match_id, events, freeze_frames)
 
-    figure = build_replay_figure(events, freeze_frames, shots, teams, match_info)
-    figure.write_html(str(args.output), include_plotlyjs="cdn")
-    print(f"Replay saved to {args.output}")
+def main() -> None:
+    args = parse_args()
+
+    matches = discover_three_sixty_matches(
+        competition_filter=args.competition_id,
+        season_filter=args.season_id,
+        limit=args.max_matches,
+    )
+
+    if args.list:
+        if not matches:
+            print("No matches with StatsBomb 360 data were found for the given filters.")
+            return
+        print("Matches with StatsBomb 360 data:")
+        for summary in matches:
+            print(
+                f"match_id={summary.match_id} | {summary.match_date} | "
+                f"{summary.home_team_name} vs {summary.away_team_name} | "
+                f"{summary.competition_name} {summary.season_name} | "
+                f"freeze frames: {summary.freeze_frame_events}"
+            )
+        return
+
+    match = select_match(matches, args.match_id)
+
+    freeze_frames = load_freeze_frames(match.match_id)
+    if not freeze_frames:
+        raise RuntimeError(
+            f"Match {match.match_id} no longer exposes StatsBomb 360 data."
+        )
+
+    events = load_events(match.match_id)
+    player_map = load_lineups(match.match_id)
+
+    flip = determine_orientation(freeze_frames, player_map, match.home_team_id)
+
+    frames, timeline_markers = prepare_animation_frames(
+        events,
+        freeze_frames,
+        player_map,
+        match.home_team_id,
+        match.away_team_id,
+        flip,
+        match.home_team_name,
+        match.away_team_name,
+    )
+
+    processed_path = save_processed_stream(
+        match,
+        frames,
+        timeline_markers,
+        CACHE_DIR / "processed",
+    )
+
+    make_animation(match, frames, timeline_markers, args.output, args.playback_speed)
+
+    print(f"Replay saved to {args.output.resolve()}")
+    print(f"Processed freeze-frame data cached at {processed_path.resolve()}")
 
 
 if __name__ == "__main__":
     main()
+

--- a/replay_generator.py
+++ b/replay_generator.py
@@ -124,6 +124,7 @@ class FreezeFrameRecord:
     team_id: Optional[int]
     team_name: Optional[str]
     side: Optional[str]
+    jersey_number: Optional[int]
     x: Optional[float]
     y: Optional[float]
     teammate: bool
@@ -304,6 +305,39 @@ def orient_visible_area(
     return oriented
 
 
+def infer_home_orientation(
+    freeze_by_event: Dict[str, dict], players: Dict[int, PlayerInfo]
+) -> bool:
+    """Return True if the home team already occupies the left side of the pitch."""
+
+    for freeze_entry in freeze_by_event.values():
+        freeze_frame = freeze_entry.get("freeze_frame") or []
+        if not freeze_frame:
+            continue
+        home_samples: List[float] = []
+        away_samples: List[float] = []
+        for player in freeze_frame:
+            player_info = player.get("player") or {}
+            player_id = player_info.get("id")
+            if player_id is None:
+                continue
+            info = players.get(player_id)
+            if info is None:
+                continue
+            location = player.get("location") or []
+            if len(location) < 2 or location[0] is None:
+                continue
+            if info.side == "home":
+                home_samples.append(float(location[0]))
+            elif info.side == "away":
+                away_samples.append(float(location[0]))
+        if home_samples and away_samples:
+            home_mean = sum(home_samples) / len(home_samples)
+            away_mean = sum(away_samples) / len(away_samples)
+            return home_mean <= away_mean
+    return True
+
+
 def compute_event_detail(event: dict) -> Tuple[Optional[str], Optional[str]]:
     event_type = event.get("type", {}).get("name")
     detail = None
@@ -356,6 +390,7 @@ def process_events(
     freeze_by_event: Dict[str, dict],
     players: Dict[int, PlayerInfo],
     teams: Dict[int, TeamInfo],
+    flip_orientation: bool,
 ) -> Tuple[List[EventRecord], List[FreezeFrameRecord], List[ShotRecord]]:
     events: List[EventRecord] = []
     freeze_records: List[FreezeFrameRecord] = []
@@ -392,6 +427,11 @@ def process_events(
         carry_end_location = normalise_location(event.get("carry", {}).get("end_location"))
         shot_end_location = normalise_location(event.get("shot", {}).get("end_location"))
 
+        oriented_location = orient_location(location, flip_orientation)
+        oriented_end_location = orient_location(end_location, flip_orientation)
+        oriented_carry_end = orient_location(carry_end_location, flip_orientation)
+        oriented_shot_end = orient_location(shot_end_location, flip_orientation)
+
         shot_info = event.get("shot")
         shot_xg = float(shot_info.get("statsbomb_xg", 0.0)) if shot_info else 0.0
         shot_outcome = shot_info.get("outcome", {}).get("name") if shot_info else None
@@ -415,8 +455,8 @@ def process_events(
                 ShotRecord(
                     minute=minute,
                     second=second,
-                    x=location[0],
-                    y=location[1],
+                    x=oriented_location[0],
+                    y=oriented_location[1],
                     xg=shot_xg,
                     outcome=shot_outcome or "Unknown",
                     goal=is_goal,
@@ -426,6 +466,9 @@ def process_events(
 
         possession_team_id = event.get("possession_team", {}).get("id")
         possession_team_name = event.get("possession_team", {}).get("name")
+        if possession_team_id is None and team_id is not None:
+            possession_team_id = team_id
+            possession_team_name = team_name
         possession_change = False
         possession_from = previous_possession_team
         possession_to = possession_team_id
@@ -433,13 +476,8 @@ def process_events(
             possession_change = previous_possession_team is not None
             previous_possession_team = possession_team_id
 
-        possession_team_info = teams.get(possession_team_id) if possession_team_id else None
-        if possession_team_info is None:
-            possession_team_info = team_info
-        freeze_needs_flip = bool(possession_team_info and possession_team_info.side == "away")
-
         raw_visible_area = freeze_by_event.get(event_uuid, {}).get("visible_area")
-        visible_area = orient_visible_area(raw_visible_area, freeze_needs_flip)
+        visible_area = orient_visible_area(raw_visible_area, flip_orientation)
 
         record = EventRecord(
             index=index,
@@ -460,10 +498,10 @@ def process_events(
             possession_change=possession_change,
             possession_from=possession_from,
             possession_to=possession_to,
-            location=location,
-            end_location=end_location,
-            carry_end_location=carry_end_location,
-            shot_end_location=shot_end_location,
+            location=oriented_location,
+            end_location=oriented_end_location,
+            carry_end_location=oriented_carry_end,
+            shot_end_location=oriented_shot_end,
             shot_xg=shot_xg,
             shot_outcome=shot_outcome,
             is_goal=is_goal,
@@ -486,9 +524,7 @@ def process_events(
             player_id_ff = player_entry.get("id")
             info = players.get(player_id_ff)
             raw_location = player.get("location") or [None, None]
-            location = orient_location(
-                (raw_location[0], raw_location[1]), freeze_needs_flip
-            )
+            location = orient_location((raw_location[0], raw_location[1]), flip_orientation)
             freeze_records.append(
                 FreezeFrameRecord(
                     event_uuid=event_uuid,
@@ -497,6 +533,7 @@ def process_events(
                     team_id=info.team_id if info else None,
                     team_name=info.team_name if info else None,
                     side=info.side if info else None,
+                    jersey_number=info.jersey_number if info else None,
                     x=location[0],
                     y=location[1],
                     teammate=bool(player.get("teammate")),
@@ -673,17 +710,21 @@ def split_freeze_players(
 ) -> Tuple[go.Scatter, go.Scatter]:
     home_x: List[Optional[float]] = []
     home_y: List[Optional[float]] = []
-    home_text: List[str] = []
+    home_numbers: List[str] = []
     home_sizes: List[float] = []
     home_line_colors: List[str] = []
     home_line_widths: List[float] = []
+    home_hover: List[str] = []
+    home_symbols: List[str] = []
 
     away_x: List[Optional[float]] = []
     away_y: List[Optional[float]] = []
-    away_text: List[str] = []
+    away_numbers: List[str] = []
     away_sizes: List[float] = []
     away_line_colors: List[str] = []
     away_line_widths: List[float] = []
+    away_hover: List[str] = []
+    away_symbols: List[str] = []
 
     for player in freeze_entry:
         text = player.player_name or "Unknown"
@@ -693,55 +734,77 @@ def split_freeze_players(
             label = text
             if player.keeper:
                 label = f"{label} (GK)"
-            home_text.append(label)
+            jersey = str(player.jersey_number) if player.jersey_number is not None else ""
+            if player.actor and not jersey:
+                jersey = "★"
+            if not jersey and player.player_name:
+                jersey = player.player_name.split()[-1][:2].upper()
+            home_numbers.append(jersey)
+            home_hover.append(label)
             size = 22 if player.actor else 16
             line_color = "#ffd700" if player.actor else "white"
             home_sizes.append(size)
             home_line_colors.append(line_color)
             home_line_widths.append(3 if player.actor else 1.5)
+            symbol = "star" if player.actor else ("hexagon" if player.keeper else "circle")
+            home_symbols.append(symbol)
         elif player.side == "away":
             away_x.append(player.x)
             away_y.append(player.y)
             label = text
             if player.keeper:
                 label = f"{label} (GK)"
-            away_text.append(label)
+            jersey = str(player.jersey_number) if player.jersey_number is not None else ""
+            if player.actor and not jersey:
+                jersey = "★"
+            if not jersey and player.player_name:
+                jersey = player.player_name.split()[-1][:2].upper()
+            away_numbers.append(jersey)
+            away_hover.append(label)
             size = 22 if player.actor else 16
             line_color = "#ffd700" if player.actor else "white"
             away_sizes.append(size)
             away_line_colors.append(line_color)
             away_line_widths.append(3 if player.actor else 1.5)
+            symbol = "star" if player.actor else ("hexagon" if player.keeper else "circle")
+            away_symbols.append(symbol)
 
     home_trace = go.Scatter(
         x=home_x,
         y=home_y,
-        mode="markers",
+        mode="markers+text",
         marker=dict(
             color=home_color,
             size=home_sizes,
-            symbol="circle",
+            symbol=home_symbols if home_symbols else "circle",
             line=dict(color=home_line_colors, width=home_line_widths),
             opacity=0.95,
         ),
-        text=home_text,
+        text=home_numbers,
+        textposition="middle center",
+        textfont=dict(color="white", size=11, family="DejaVu Sans"),
+        hovertext=home_hover,
         name="Home team",
-        hovertemplate="%{text}<extra></extra>",
+        hovertemplate="%{hovertext}<extra></extra>",
         showlegend=False,
     )
     away_trace = go.Scatter(
         x=away_x,
         y=away_y,
-        mode="markers",
+        mode="markers+text",
         marker=dict(
             color=away_color,
             size=away_sizes,
-            symbol="circle",
+            symbol=away_symbols if away_symbols else "circle",
             line=dict(color=away_line_colors, width=away_line_widths),
             opacity=0.95,
         ),
-        text=away_text,
+        text=away_numbers,
+        textposition="middle center",
+        textfont=dict(color="white", size=11, family="DejaVu Sans"),
+        hovertext=away_hover,
         name="Away team",
-        hovertemplate="%{text}<extra></extra>",
+        hovertemplate="%{hovertext}<extra></extra>",
         showlegend=False,
     )
     return home_trace, away_trace
@@ -1100,7 +1163,7 @@ def build_replay_figure(
 
     fig.frames = frames
     frame_names = [frame.name for frame in frames]
-    default_frame_duration = 420
+    default_frame_duration = 260
 
     fig.update_layout(
         width=1320,
@@ -1110,8 +1173,9 @@ def build_replay_figure(
         plot_bgcolor="#0b6623",
         paper_bgcolor="#123524",
         font=dict(color="white"),
+        hovermode="closest",
         margin=dict(l=40, r=40, t=80, b=40),
-        transition=dict(duration=default_frame_duration, easing="linear"),
+        transition=dict(duration=default_frame_duration, easing="quad-in-out"),
         sliders=[
             dict(
                 active=0,
@@ -1120,7 +1184,7 @@ def build_replay_figure(
                 steps=slider_steps,
                 x=0.1,
                 len=0.75,
-                transition=dict(duration=200, easing="linear"),
+                transition=dict(duration=200, easing="quad-in-out"),
             )
         ],
         updatemenus=[
@@ -1135,7 +1199,7 @@ def build_replay_figure(
                             frame_names,
                             {
                                 "frame": {"duration": default_frame_duration * 2, "redraw": True},
-                                "transition": {"duration": default_frame_duration * 2, "easing": "linear"},
+                                "transition": {"duration": default_frame_duration * 2, "easing": "quad-in-out"},
                                 "fromcurrent": True,
                                 "mode": "immediate",
                             },
@@ -1148,7 +1212,7 @@ def build_replay_figure(
                             frame_names,
                             {
                                 "frame": {"duration": default_frame_duration, "redraw": True},
-                                "transition": {"duration": default_frame_duration, "easing": "linear"},
+                                "transition": {"duration": default_frame_duration, "easing": "quad-in-out"},
                                 "fromcurrent": True,
                                 "mode": "immediate",
                             },
@@ -1161,7 +1225,7 @@ def build_replay_figure(
                             frame_names,
                             {
                                 "frame": {"duration": max(120, default_frame_duration // 2), "redraw": True},
-                                "transition": {"duration": max(120, default_frame_duration // 2), "easing": "linear"},
+                                "transition": {"duration": max(120, default_frame_duration // 2), "easing": "quad-in-out"},
                                 "fromcurrent": True,
                                 "mode": "immediate",
                             },
@@ -1350,7 +1414,14 @@ def main() -> None:
     teams = build_team_directory(match_info)
     players = build_player_directory(lineups, teams)
     freeze_lookup = freeze_frames_by_event(freeze_data)
-    events, freeze_frames, shots = process_events(events_data, freeze_lookup, players, teams)
+    home_already_left = infer_home_orientation(freeze_lookup, players)
+    events, freeze_frames, shots = process_events(
+        events_data,
+        freeze_lookup,
+        players,
+        teams,
+        flip_orientation=not home_already_left,
+    )
 
     manager.save_processed_dataset(args.match_id, events, freeze_frames)
 

--- a/replay_generator.py
+++ b/replay_generator.py
@@ -36,6 +36,9 @@ GITHUB_API_THREE_SIXTY = (
     "https://api.github.com/repos/statsbomb/open-data/contents/data/three-sixty"
 )
 
+PITCH_LENGTH = 120.0
+PITCH_WIDTH = 80.0
+
 
 @dataclass
 class TeamInfo:
@@ -273,6 +276,34 @@ def normalise_location(value: Optional[Iterable[Optional[float]]]) -> Tuple[Opti
     return (coords[0], coords[1])
 
 
+def orient_location(
+    location: Tuple[Optional[float], Optional[float]], flip: bool
+) -> Tuple[Optional[float], Optional[float]]:
+    if not flip:
+        return location
+    x, y = location
+    oriented_x = PITCH_LENGTH - x if x is not None else None
+    oriented_y = PITCH_WIDTH - y if y is not None else None
+    return (oriented_x, oriented_y)
+
+
+def orient_visible_area(
+    visible_area: Optional[List[float]], flip: bool
+) -> Optional[List[float]]:
+    if not visible_area or not flip:
+        return visible_area
+    oriented: List[float] = []
+    for idx, value in enumerate(visible_area):
+        if value is None:
+            oriented.append(value)
+            continue
+        if idx % 2 == 0:
+            oriented.append(PITCH_LENGTH - value)
+        else:
+            oriented.append(PITCH_WIDTH - value)
+    return oriented
+
+
 def compute_event_detail(event: dict) -> Tuple[Optional[str], Optional[str]]:
     event_type = event.get("type", {}).get("name")
     detail = None
@@ -402,6 +433,14 @@ def process_events(
             possession_change = previous_possession_team is not None
             previous_possession_team = possession_team_id
 
+        possession_team_info = teams.get(possession_team_id) if possession_team_id else None
+        if possession_team_info is None:
+            possession_team_info = team_info
+        freeze_needs_flip = bool(possession_team_info and possession_team_info.side == "away")
+
+        raw_visible_area = freeze_by_event.get(event_uuid, {}).get("visible_area")
+        visible_area = orient_visible_area(raw_visible_area, freeze_needs_flip)
+
         record = EventRecord(
             index=index,
             event_uuid=event_uuid,
@@ -437,7 +476,7 @@ def process_events(
             xg_home=xg_home,
             xg_away=xg_away,
             period=int(event.get("period", 1)),
-            visible_area=freeze_by_event.get(event_uuid, {}).get("visible_area"),
+            visible_area=visible_area,
         )
         events.append(record)
 
@@ -446,6 +485,10 @@ def process_events(
             player_entry = player.get("player") or {}
             player_id_ff = player_entry.get("id")
             info = players.get(player_id_ff)
+            raw_location = player.get("location") or [None, None]
+            location = orient_location(
+                (raw_location[0], raw_location[1]), freeze_needs_flip
+            )
             freeze_records.append(
                 FreezeFrameRecord(
                     event_uuid=event_uuid,
@@ -454,12 +497,8 @@ def process_events(
                     team_id=info.team_id if info else None,
                     team_name=info.team_name if info else None,
                     side=info.side if info else None,
-                    x=player.get("location", [None, None])[0]
-                    if player.get("location")
-                    else None,
-                    y=player.get("location", [None, None])[1]
-                    if player.get("location")
-                    else None,
+                    x=location[0],
+                    y=location[1],
                     teammate=bool(player.get("teammate")),
                     actor=bool(player.get("actor")),
                     keeper=bool(player.get("keeper")),
@@ -680,7 +719,9 @@ def split_freeze_players(
         marker=dict(
             color=home_color,
             size=home_sizes,
+            symbol="circle",
             line=dict(color=home_line_colors, width=home_line_widths),
+            opacity=0.95,
         ),
         text=home_text,
         name="Home team",
@@ -694,7 +735,9 @@ def split_freeze_players(
         marker=dict(
             color=away_color,
             size=away_sizes,
+            symbol="circle",
             line=dict(color=away_line_colors, width=away_line_widths),
+            opacity=0.95,
         ),
         text=away_text,
         name="Away team",
@@ -830,14 +873,28 @@ def build_replay_figure(
     home_players, away_players = split_freeze_players(first_freeze, home_color, away_color)
     ball_position = infer_ball_position(first_event, first_freeze)
 
+    dynamic_trace_indices: List[int] = []
+
+    home_trace_index = len(fig.data)
     fig.add_trace(home_players, row=1, col=1)
+    dynamic_trace_indices.append(home_trace_index)
+
+    away_trace_index = len(fig.data)
     fig.add_trace(away_players, row=1, col=1)
+    dynamic_trace_indices.append(away_trace_index)
+
+    ball_trace_index = len(fig.data)
     fig.add_trace(
         go.Scatter(
             x=[ball_position[0]] if ball_position[0] is not None else [None],
             y=[ball_position[1]] if ball_position[1] is not None else [None],
             mode="markers",
-            marker=dict(color="#fefefe", size=16, line=dict(color="black", width=2)),
+            marker=dict(
+                color="#fefefe",
+                size=16,
+                line=dict(color="black", width=2),
+                symbol="circle",
+            ),
             name="Ball",
             hoverinfo="skip",
             showlegend=False,
@@ -845,47 +902,107 @@ def build_replay_figure(
         row=1,
         col=1,
     )
+    dynamic_trace_indices.append(ball_trace_index)
+
+    event_text_index = len(fig.data)
     fig.add_trace(
         go.Scatter(
             x=[60],
-            y=[-5],
+            y=[-2],
             mode="text",
             text=[build_event_summary(first_event, teams)],
             textfont=dict(color="white", size=14),
+            textposition="top center",
             showlegend=False,
             hoverinfo="none",
         ),
         row=1,
         col=1,
     )
+    dynamic_trace_indices.append(event_text_index)
+
+    scoreboard_text_index = len(fig.data)
     fig.add_trace(
         go.Scatter(
-            x=[0],
-            y=[0],
+            x=[0.05],
+            y=[0.9],
             mode="text",
             text=[build_scoreboard_text(first_event, teams)],
-            textfont=dict(color="white", size=14),
+            textfont=dict(color="white", size=15),
+            textposition="top left",
             showlegend=False,
             hoverinfo="none",
         ),
         row=1,
         col=2,
     )
+    dynamic_trace_indices.append(scoreboard_text_index)
+
+    timeline_marker_index = len(fig.data)
     fig.add_trace(
         go.Scatter(
             x=[first_event.match_time_minutes],
             y=[0],
             mode="markers",
-            marker=dict(color="#ffff00", size=20, symbol="line-ns-open"),
+            marker=dict(color="#ffff00", size=18, symbol="line-ns-open"),
             showlegend=False,
             hoverinfo="skip",
         ),
         row=2,
         col=1,
     )
+    dynamic_trace_indices.append(timeline_marker_index)
 
-    fig.update_xaxes(range=[-1, 1], visible=False, row=1, col=2)
-    fig.update_yaxes(range=[-1, 1], visible=False, row=1, col=2)
+    shot_highlight_index = len(fig.data)
+    has_initial_shot = (
+        first_event.event_type == "Shot"
+        and first_event.location != (None, None)
+        and first_event.shot_end_location != (None, None)
+    )
+    if not has_initial_shot:
+        shot_x = [None]
+        shot_y = [None]
+        shot_line_color = "rgba(0,0,0,0)"
+    else:
+        shot_x = [first_event.location[0], first_event.shot_end_location[0]]
+        shot_y = [first_event.location[1], first_event.shot_end_location[1]]
+        shot_line_color = "#ffd700" if first_event.is_goal else "#ffffaa"
+    fig.add_trace(
+        go.Scatter(
+            x=shot_x,
+            y=shot_y,
+            mode="lines+markers",
+            line=dict(color=shot_line_color, width=3, dash="dot"),
+            marker=dict(
+                color=shot_line_color,
+                size=10,
+                symbol="circle-open",
+                line=dict(color=shot_line_color, width=2),
+            ),
+            hoverinfo="skip",
+            showlegend=False,
+        ),
+        row=1,
+        col=1,
+    )
+    dynamic_trace_indices.append(shot_highlight_index)
+
+    fig.update_xaxes(range=[0, 1], visible=False, row=1, col=2)
+    fig.update_yaxes(range=[0, 1], visible=False, row=1, col=2)
+    fig.add_shape(
+        type="rect",
+        x0=0,
+        y0=0,
+        x1=1,
+        y1=1,
+        xref="x2",
+        yref="y2",
+        fillcolor="rgba(27, 67, 50, 0.85)",
+        line=dict(color="rgba(255,255,255,0.2)", width=1),
+        layer="below",
+        row=1,
+        col=2,
+    )
 
     frames = []
     slider_steps = []
@@ -895,47 +1012,82 @@ def build_replay_figure(
             freeze_records_for_event, home_color, away_color
         )
         ball_x, ball_y = infer_ball_position(event, freeze_records_for_event)
+        has_shot = (
+            event.event_type == "Shot"
+            and event.location != (None, None)
+            and event.shot_end_location != (None, None)
+        )
+        if has_shot:
+            shot_x = [event.location[0], event.shot_end_location[0]]
+            shot_y = [event.location[1], event.shot_end_location[1]]
+            shot_line_color = "#ffd700" if event.is_goal else "#ffffaa"
+        else:
+            shot_x = [None]
+            shot_y = [None]
+            shot_line_color = "rgba(0,0,0,0)"
+        frame_data = [
+            home_trace,
+            away_trace,
+            go.Scatter(
+                x=[ball_x] if ball_x is not None else [None],
+                y=[ball_y] if ball_y is not None else [None],
+                mode="markers",
+                marker=dict(
+                    color="#fefefe",
+                    size=16,
+                    line=dict(color="black", width=2),
+                    symbol="circle",
+                ),
+                showlegend=False,
+                hoverinfo="skip",
+            ),
+            go.Scatter(
+                x=[60],
+                y=[-2],
+                mode="text",
+                text=[build_event_summary(event, teams)],
+                textfont=dict(color="white", size=14),
+                textposition="top center",
+                showlegend=False,
+                hoverinfo="none",
+            ),
+            go.Scatter(
+                x=[0.05],
+                y=[0.9],
+                mode="text",
+                text=[build_scoreboard_text(event, teams)],
+                textfont=dict(color="white", size=15),
+                textposition="top left",
+                showlegend=False,
+                hoverinfo="none",
+            ),
+            go.Scatter(
+                x=[event.match_time_minutes],
+                y=[0],
+                mode="markers",
+                marker=dict(color="#ffff00", size=18, symbol="line-ns-open"),
+                showlegend=False,
+                hoverinfo="skip",
+            ),
+            go.Scatter(
+                x=shot_x,
+                y=shot_y,
+                mode="lines+markers",
+                line=dict(color=shot_line_color, width=3, dash="dot"),
+                marker=dict(
+                    color=shot_line_color,
+                    size=10,
+                    symbol="circle-open",
+                    line=dict(color=shot_line_color, width=2),
+                ),
+                showlegend=False,
+                hoverinfo="skip",
+            ),
+        ]
         frame = go.Frame(
-            data=[
-                home_trace,
-                away_trace,
-                go.Scatter(
-                    x=[ball_x] if ball_x is not None else [None],
-                    y=[ball_y] if ball_y is not None else [None],
-                    mode="markers",
-                    marker=dict(color="#fefefe", size=16, line=dict(color="black", width=2)),
-                    showlegend=False,
-                    hoverinfo="skip",
-                ),
-                go.Scatter(
-                    x=[60],
-                    y=[-5],
-                    mode="text",
-                    text=[build_event_summary(event, teams)],
-                    textfont=dict(color="white", size=14),
-                    showlegend=False,
-                    hoverinfo="none",
-                ),
-                go.Scatter(
-                    x=[0],
-                    y=[0],
-                    mode="text",
-                    text=[build_scoreboard_text(event, teams)],
-                    textfont=dict(color="white", size=14),
-                    showlegend=False,
-                    hoverinfo="none",
-                ),
-                go.Scatter(
-                    x=[event.match_time_minutes],
-                    y=[0],
-                    mode="markers",
-                    marker=dict(color="#ffff00", size=20, symbol="line-ns-open"),
-                    showlegend=False,
-                    hoverinfo="skip",
-                ),
-            ],
+            data=frame_data,
             name=str(idx),
-            traces=[3, 4, 5, 6, 7, 8],
+            traces=dynamic_trace_indices,
         )
         frames.append(frame)
         slider_steps.append(
@@ -947,16 +1099,19 @@ def build_replay_figure(
         )
 
     fig.frames = frames
+    frame_names = [frame.name for frame in frames]
+    default_frame_duration = 420
 
     fig.update_layout(
-        width=1200,
-        height=800,
+        width=1320,
+        height=860,
         showlegend=True,
         legend=dict(bgcolor="rgba(0,0,0,0)", font=dict(color="white")),
         plot_bgcolor="#0b6623",
         paper_bgcolor="#123524",
         font=dict(color="white"),
         margin=dict(l=40, r=40, t=80, b=40),
+        transition=dict(duration=default_frame_duration, easing="linear"),
         sliders=[
             dict(
                 active=0,
@@ -964,7 +1119,8 @@ def build_replay_figure(
                 pad=dict(t=30),
                 steps=slider_steps,
                 x=0.1,
-                len=0.7,
+                len=0.75,
+                transition=dict(duration=200, easing="linear"),
             )
         ],
         updatemenus=[
@@ -973,14 +1129,52 @@ def build_replay_figure(
                 direction="left",
                 buttons=[
                     dict(
-                        label="Play",
+                        label="⏯ Slow",
                         method="animate",
-                        args=[[frame.name for frame in frames], {"frame": {"duration": 200, "redraw": True}, "fromcurrent": True}],
+                        args=[
+                            frame_names,
+                            {
+                                "frame": {"duration": default_frame_duration * 2, "redraw": True},
+                                "transition": {"duration": default_frame_duration * 2, "easing": "linear"},
+                                "fromcurrent": True,
+                                "mode": "immediate",
+                            },
+                        ],
                     ),
-                    dict(label="Pause", method="animate", args=[[None], {"frame": {"duration": 0}, "mode": "immediate"}]),
+                    dict(
+                        label="▶ Normal",
+                        method="animate",
+                        args=[
+                            frame_names,
+                            {
+                                "frame": {"duration": default_frame_duration, "redraw": True},
+                                "transition": {"duration": default_frame_duration, "easing": "linear"},
+                                "fromcurrent": True,
+                                "mode": "immediate",
+                            },
+                        ],
+                    ),
+                    dict(
+                        label="⏩ Fast",
+                        method="animate",
+                        args=[
+                            frame_names,
+                            {
+                                "frame": {"duration": max(120, default_frame_duration // 2), "redraw": True},
+                                "transition": {"duration": max(120, default_frame_duration // 2), "easing": "linear"},
+                                "fromcurrent": True,
+                                "mode": "immediate",
+                            },
+                        ],
+                    ),
+                    dict(
+                        label="⏸ Pause",
+                        method="animate",
+                        args=[[None], {"frame": {"duration": 0}, "mode": "immediate"}],
+                    ),
                 ],
                 pad=dict(t=30, r=10),
-                x=0.85,
+                x=0.88,
                 y=1.07,
                 bgcolor="#1b4332",
             )

--- a/replay_generator.py
+++ b/replay_generator.py
@@ -27,10 +27,9 @@ from typing import Dict, Iterable, List, Optional, Tuple
 try:
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
-except ModuleNotFoundError as exc:  # pragma: no cover - handled at runtime
-    raise SystemExit(
-        "Plotly is required to run this script. Install it with 'pip install plotly'."
-    ) from exc
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    go = None
+    make_subplots = None
 
 DATA_REPO_URL = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
 GITHUB_API_THREE_SIXTY = (
@@ -161,6 +160,11 @@ class DataManager:
             raise RuntimeError(f"Failed to fetch {url}: {exc}") from exc
         cache_path.write_text(payload, encoding="utf-8")
         return json.loads(payload)
+
+    def get_competitions(self) -> List[dict]:
+        url = f"{DATA_REPO_URL}/competitions.json"
+        cache_path = self.raw_dir / "competitions.json"
+        return self._fetch_json(url, cache_path)
 
     def get_matches(self, competition_id: int, season_id: int) -> List[dict]:
         url = f"{DATA_REPO_URL}/matches/{competition_id}/{season_id}.json"
@@ -716,6 +720,11 @@ def build_replay_figure(
     teams: Dict[int, TeamInfo],
     match_info: dict,
 ) -> go.Figure:
+    if go is None or make_subplots is None:  # pragma: no cover - runtime dependency
+        raise SystemExit(
+            "Plotly is required to build the replay figure. Install it with 'pip install plotly'."
+        )
+
     freeze_lookup: Dict[str, List[FreezeFrameRecord]] = {}
     for frame in freeze_frames:
         freeze_lookup.setdefault(frame.event_uuid, []).append(frame)
@@ -995,34 +1004,78 @@ def build_replay_figure(
     return fig
 
 
+def build_three_sixty_catalog(manager: DataManager) -> Dict[int, dict]:
+    match_ids = set(manager.list_three_sixty_match_ids())
+    competitions = manager.get_competitions()
+    catalog: Dict[int, dict] = {}
+    remaining = set(match_ids)
+    for competition in competitions:
+        competition_id = competition.get("competition_id")
+        season_id = competition.get("season_id")
+        if competition_id is None or season_id is None:
+            continue
+        matches = manager.get_matches(int(competition_id), int(season_id))
+        for match in matches:
+            match_id = match.get("match_id")
+            if match_id in remaining:
+                catalog[int(match_id)] = {
+                    "match": match,
+                    "competition": competition,
+                    "competition_id": int(competition_id),
+                    "season_id": int(season_id),
+                }
+                remaining.remove(match_id)
+        if not remaining:
+            break
+    return catalog
+
+
 def list_matches_with_three_sixty(
-    manager: DataManager,
-    competition_id: int,
-    season_id: int,
+    catalog: Dict[int, dict],
+    competition_id: Optional[int] = None,
+    season_id: Optional[int] = None,
+    team_query: Optional[str] = None,
 ) -> None:
-    three_sixty_ids = set(manager.list_three_sixty_match_ids())
-    matches = manager.get_matches(competition_id, season_id)
+    team_query_normalised = team_query.lower() if team_query else None
     rows = []
-    for match in matches:
-        match_id = match.get("match_id")
-        if match_id in three_sixty_ids:
-            rows.append(
-                (
-                    match_id,
-                    match.get("match_date"),
-                    match.get("home_team", {}).get("home_team_name"),
-                    match.get("away_team", {}).get("away_team_name"),
-                    match.get("competition_stage", {}).get("name"),
-                )
+    for match_id, entry in catalog.items():
+        comp_id = entry["competition_id"]
+        comp_season = entry["season_id"]
+        if competition_id is not None and comp_id != competition_id:
+            continue
+        if season_id is not None and comp_season != season_id:
+            continue
+        match = entry["match"]
+        home = match.get("home_team", {}).get("home_team_name", "Unknown")
+        away = match.get("away_team", {}).get("away_team_name", "Unknown")
+        if team_query_normalised and team_query_normalised not in home.lower() and team_query_normalised not in away.lower():
+            continue
+        rows.append(
+            (
+                match_id,
+                match.get("match_date"),
+                home,
+                away,
+                match.get("competition_stage", {}).get("name"),
+                entry["competition"].get("competition_name"),
+                entry["competition"].get("season_name"),
             )
+        )
     if not rows:
-        print("No matches with 360 data found for the selected competition/season.")
+        print("No matches with 360 data found that match the given filters.")
         return
-    header = f"{'Match ID':>8}  {'Date':<12}  {'Home':<25}  {'Away':<25}  {'Stage'}"
+    rows.sort(key=lambda item: (item[1] or "", item[0]))
+    header = (
+        f"{'Match ID':>8}  {'Date':<12}  {'Home':<25}  {'Away':<25}  {'Stage':<15}  "
+        f"{'Competition':<25}  {'Season'}"
+    )
     print(header)
     print("-" * len(header))
-    for match_id, date, home, away, stage in rows:
-        print(f"{match_id:>8}  {date:<12}  {home:<25}  {away:<25}  {stage}")
+    for match_id, date, home, away, stage, competition_name, season_name in rows:
+        print(
+            f"{match_id:>8}  {str(date):<12}  {home:<25}  {away:<25}  {str(stage):<15}  "
+            f"{str(competition_name):<25}  {str(season_name)}"
+        )
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -1030,8 +1083,16 @@ def parse_arguments() -> argparse.Namespace:
         description="Generate an interactive replay for a StatsBomb 360 match.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--competition-id", type=int, required=True, help="StatsBomb competition id")
-    parser.add_argument("--season-id", type=int, required=True, help="StatsBomb season id")
+    parser.add_argument(
+        "--competition-id",
+        type=int,
+        help="Optional StatsBomb competition id filter when listing matches",
+    )
+    parser.add_argument(
+        "--season-id",
+        type=int,
+        help="Optional StatsBomb season id filter when listing matches",
+    )
     parser.add_argument("--match-id", type=int, help="StatsBomb match id")
     parser.add_argument(
         "--output",
@@ -1048,7 +1109,12 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--list-matches",
         action="store_true",
-        help="List all matches with 360 data for the selected competition/season and exit",
+        help="List all matches with 360 data (optionally filtered) and exit",
+    )
+    parser.add_argument(
+        "--team",
+        type=str,
+        help="Filter listed matches by team name (case insensitive substring)",
     )
     return parser.parse_args()
 
@@ -1056,24 +1122,29 @@ def parse_arguments() -> argparse.Namespace:
 def main() -> None:
     args = parse_arguments()
     manager = DataManager(args.data_dir)
+    catalog = build_three_sixty_catalog(manager)
 
     if args.list_matches:
         if args.match_id:
             print("--match-id is ignored when --list-matches is supplied.")
-        list_matches_with_three_sixty(manager, args.competition_id, args.season_id)
+        list_matches_with_three_sixty(
+            catalog,
+            competition_id=args.competition_id,
+            season_id=args.season_id,
+            team_query=args.team,
+        )
         return
 
     if args.match_id is None:
         raise SystemExit("--match-id is required unless --list-matches is used")
 
-    matches = manager.get_matches(args.competition_id, args.season_id)
-    match_info = None
-    for match in matches:
-        if match.get("match_id") == args.match_id:
-            match_info = match
-            break
-    if match_info is None:
-        raise SystemExit("Match not found in the selected competition/season")
+    match_entry = catalog.get(args.match_id)
+    if match_entry is None:
+        raise SystemExit(
+            "Match not found among StatsBomb 360 fixtures. Run with --list-matches to discover available ids."
+        )
+
+    match_info = match_entry["match"]
 
     freeze_data = manager.get_three_sixty(args.match_id)
     if not freeze_data:

--- a/replay_generator.py
+++ b/replay_generator.py
@@ -1,0 +1,1098 @@
+#!/usr/bin/env python3
+"""StatsBomb 360 match replay generator.
+
+This script downloads StatsBomb open data (events and 360 freeze frames)
+for a single match and builds an interactive Plotly playback that can be
+used to visually replay the match phase by phase. The resulting HTML
+contains a slider-driven animation of the players on a full pitch,
+annotated with event metadata, possession changes, ball carrier details,
+and a rich set of shot-related insights.
+
+Alongside the visual output the script caches the raw data locally and
+stores tidy JSON representations of the processed events and freeze frame
+snapshots, making it easier to re-use the data for future analysis (for
+example, Markov decision process modelling).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+try:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+except ModuleNotFoundError as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(
+        "Plotly is required to run this script. Install it with 'pip install plotly'."
+    ) from exc
+
+DATA_REPO_URL = "https://raw.githubusercontent.com/statsbomb/open-data/master/data"
+GITHUB_API_THREE_SIXTY = (
+    "https://api.github.com/repos/statsbomb/open-data/contents/data/three-sixty"
+)
+
+
+@dataclass
+class TeamInfo:
+    team_id: int
+    name: str
+    side: str  # "home" or "away"
+
+
+@dataclass
+class PlayerInfo:
+    player_id: int
+    name: str
+    jersey_number: Optional[int]
+    team_id: int
+    team_name: str
+    side: str
+
+
+@dataclass
+class ShotRecord:
+    minute: int
+    second: int
+    x: Optional[float]
+    y: Optional[float]
+    xg: float
+    outcome: str
+    goal: bool
+    team_side: str
+
+
+@dataclass
+class EventRecord:
+    index: int
+    event_uuid: str
+    minute: int
+    second: int
+    timestamp: str
+    team_id: Optional[int]
+    team_name: Optional[str]
+    player_id: Optional[int]
+    player_name: Optional[str]
+    event_type: str
+    detail: Optional[str]
+    outcome: Optional[str]
+    possession_team_id: Optional[int]
+    possession_team_name: Optional[str]
+    possession_number: Optional[int]
+    possession_change: bool
+    possession_from: Optional[int]
+    possession_to: Optional[int]
+    location: Tuple[Optional[float], Optional[float]]
+    end_location: Tuple[Optional[float], Optional[float]]
+    carry_end_location: Tuple[Optional[float], Optional[float]]
+    shot_end_location: Tuple[Optional[float], Optional[float]]
+    shot_xg: float
+    shot_outcome: Optional[str]
+    is_goal: bool
+    score_home: int
+    score_away: int
+    shots_home: int
+    shots_away: int
+    shots_on_target_home: int
+    shots_on_target_away: int
+    xg_home: float
+    xg_away: float
+    period: int
+    visible_area: Optional[List[float]]
+
+    @property
+    def match_time_minutes(self) -> float:
+        return self.minute + self.second / 60.0
+
+    @property
+    def match_time_seconds(self) -> float:
+        return self.minute * 60.0 + self.second
+
+
+@dataclass
+class FreezeFrameRecord:
+    event_uuid: str
+    player_id: Optional[int]
+    player_name: Optional[str]
+    team_id: Optional[int]
+    team_name: Optional[str]
+    side: Optional[str]
+    x: Optional[float]
+    y: Optional[float]
+    teammate: bool
+    actor: bool
+    keeper: bool
+
+
+class DataManager:
+    """Download and cache StatsBomb open data."""
+
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+        self.raw_dir = self.base_dir / "raw"
+        self.matches_dir = self.raw_dir / "matches"
+        self.events_dir = self.raw_dir / "events"
+        self.lineups_dir = self.raw_dir / "lineups"
+        self.three_sixty_dir = self.raw_dir / "three_sixty"
+        for directory in (
+            self.base_dir,
+            self.raw_dir,
+            self.matches_dir,
+            self.events_dir,
+            self.lineups_dir,
+            self.three_sixty_dir,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    def _fetch_json(self, url: str, cache_path: Path) -> List[dict]:
+        if cache_path.exists():
+            with cache_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        request = urllib.request.Request(url, headers={"User-Agent": "statsbomb-replay"})
+        try:
+            with urllib.request.urlopen(request) as response:
+                payload = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:  # pragma: no cover - network
+            raise RuntimeError(f"Failed to fetch {url}: {exc}") from exc
+        cache_path.write_text(payload, encoding="utf-8")
+        return json.loads(payload)
+
+    def get_matches(self, competition_id: int, season_id: int) -> List[dict]:
+        url = f"{DATA_REPO_URL}/matches/{competition_id}/{season_id}.json"
+        cache_path = self.matches_dir / f"{competition_id}_{season_id}.json"
+        return self._fetch_json(url, cache_path)
+
+    def get_events(self, match_id: int) -> List[dict]:
+        url = f"{DATA_REPO_URL}/events/{match_id}.json"
+        cache_path = self.events_dir / f"{match_id}.json"
+        return self._fetch_json(url, cache_path)
+
+    def get_three_sixty(self, match_id: int) -> List[dict]:
+        url = f"{DATA_REPO_URL}/three-sixty/{match_id}.json"
+        cache_path = self.three_sixty_dir / f"{match_id}.json"
+        return self._fetch_json(url, cache_path)
+
+    def get_lineups(self, match_id: int) -> List[dict]:
+        url = f"{DATA_REPO_URL}/lineups/{match_id}.json"
+        cache_path = self.lineups_dir / f"{match_id}.json"
+        return self._fetch_json(url, cache_path)
+
+    def list_three_sixty_match_ids(self) -> List[int]:
+        request = urllib.request.Request(
+            GITHUB_API_THREE_SIXTY,
+            headers={"User-Agent": "statsbomb-replay"},
+        )
+        try:
+            with urllib.request.urlopen(request) as response:
+                payload = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:  # pragma: no cover - network
+            raise RuntimeError(f"Failed to list 360 matches: {exc}") from exc
+        listing = json.loads(payload)
+        match_ids: List[int] = []
+        for item in listing:
+            name = item.get("name", "")
+            if name.endswith(".json"):
+                try:
+                    match_ids.append(int(name.split(".")[0]))
+                except ValueError:
+                    continue
+        return match_ids
+
+    def save_processed_dataset(
+        self,
+        match_id: int,
+        events: List[EventRecord],
+        freeze_frames: List[FreezeFrameRecord],
+    ) -> None:
+        processed_dir = self.base_dir / "processed"
+        processed_dir.mkdir(parents=True, exist_ok=True)
+        events_payload = [event.__dict__ for event in events]
+        freeze_payload = [frame.__dict__ for frame in freeze_frames]
+        (processed_dir / f"{match_id}_events.json").write_text(
+            json.dumps(events_payload, indent=2),
+            encoding="utf-8",
+        )
+        (processed_dir / f"{match_id}_freeze_frames.json").write_text(
+            json.dumps(freeze_payload, indent=2),
+            encoding="utf-8",
+        )
+
+
+def build_team_directory(match_info: dict) -> Dict[int, TeamInfo]:
+    home = match_info.get("home_team") or {}
+    away = match_info.get("away_team") or {}
+    directory: Dict[int, TeamInfo] = {}
+    if "home_team_id" in home:
+        directory[int(home["home_team_id"])] = TeamInfo(
+            team_id=int(home["home_team_id"]),
+            name=home.get("home_team_name"),
+            side="home",
+        )
+    if "away_team_id" in away:
+        directory[int(away["away_team_id"])] = TeamInfo(
+            team_id=int(away["away_team_id"]),
+            name=away.get("away_team_name"),
+            side="away",
+        )
+    return directory
+
+
+def build_player_directory(lineups: List[dict], teams: Dict[int, TeamInfo]) -> Dict[int, PlayerInfo]:
+    directory: Dict[int, PlayerInfo] = {}
+    for team_entry in lineups:
+        team_id = team_entry.get("team_id")
+        team_info = teams.get(team_id)
+        for player in team_entry.get("lineup", []):
+            player_id = player.get("player_id")
+            directory[player_id] = PlayerInfo(
+                player_id=player_id,
+                name=player.get("player_name"),
+                jersey_number=player.get("jersey_number"),
+                team_id=team_id,
+                team_name=team_info.name if team_info else None,
+                side=team_info.side if team_info else None,
+            )
+    return directory
+
+
+def normalise_location(value: Optional[Iterable[Optional[float]]]) -> Tuple[Optional[float], Optional[float]]:
+    if not value:
+        return (None, None)
+    coords = list(value)
+    if len(coords) < 2:
+        coords += [None] * (2 - len(coords))
+    return (coords[0], coords[1])
+
+
+def compute_event_detail(event: dict) -> Tuple[Optional[str], Optional[str]]:
+    event_type = event.get("type", {}).get("name")
+    detail = None
+    outcome = None
+    if event_type == "Pass":
+        pass_info = event.get("pass", {})
+        recipient = pass_info.get("recipient", {}).get("name")
+        height = pass_info.get("height", {}).get("name")
+        detail = ", ".join(
+            [
+                part
+                for part in (
+                    f"to {recipient}" if recipient else None,
+                    pass_info.get("body_part", {}).get("name"),
+                    height,
+                )
+                if part
+            ]
+        ) or None
+        outcome = pass_info.get("outcome", {}).get("name")
+    elif event_type == "Carry":
+        carry_info = event.get("carry", {})
+        detail = (
+            f"to {carry_info.get('end_location')}" if carry_info.get("end_location") else None
+        )
+    elif event_type == "Dribble":
+        detail = event.get("dribble", {}).get("outcome", {}).get("name")
+    elif event_type == "Shot":
+        shot_info = event.get("shot", {})
+        outcome = shot_info.get("outcome", {}).get("name")
+        technique = shot_info.get("technique", {}).get("name")
+        body = shot_info.get("body_part", {}).get("name")
+        detail = ", ".join([part for part in (technique, body) if part]) or None
+    elif event_type == "Pressure":
+        detail = "Counterpress" if event.get("counterpress") else None
+    elif event_type == "Ball Receipt*":
+        outcome = event.get("ball_receipt", {}).get("outcome", {}).get("name")
+    elif event_type == "Foul Won":
+        detail = "Defensive" if event.get("foul_won", {}).get("defensive") else None
+    elif event_type == "Foul Committed":
+        detail = event.get("foul_committed", {}).get("type", {}).get("name")
+    elif event_type == "Substitution":
+        sub = event.get("substitution", {})
+        detail = sub.get("replacement", {}).get("name")
+    return detail, outcome
+
+
+def process_events(
+    raw_events: List[dict],
+    freeze_by_event: Dict[str, dict],
+    players: Dict[int, PlayerInfo],
+    teams: Dict[int, TeamInfo],
+) -> Tuple[List[EventRecord], List[FreezeFrameRecord], List[ShotRecord]]:
+    events: List[EventRecord] = []
+    freeze_records: List[FreezeFrameRecord] = []
+    shots: List[ShotRecord] = []
+
+    home_team_id = next(team.team_id for team in teams.values() if team.side == "home")
+    away_team_id = next(team.team_id for team in teams.values() if team.side == "away")
+
+    score_home = 0
+    score_away = 0
+    shots_home = 0
+    shots_away = 0
+    shots_on_target_home = 0
+    shots_on_target_away = 0
+    xg_home = 0.0
+    xg_away = 0.0
+    previous_possession_team: Optional[int] = None
+
+    for index, event in enumerate(raw_events):
+        event_uuid = event.get("id")
+        minute = int(event.get("minute", 0))
+        second = int(event.get("second", 0))
+        team_id = event.get("team", {}).get("id")
+        team_info = teams.get(team_id)
+        team_name = team_info.name if team_info else event.get("team", {}).get("name")
+        player_id = event.get("player", {}).get("id")
+        player_info = players.get(player_id)
+        player_name = player_info.name if player_info else event.get("player", {}).get("name")
+        event_type = event.get("type", {}).get("name") or "Unknown"
+        detail, outcome = compute_event_detail(event)
+
+        location = normalise_location(event.get("location"))
+        end_location = normalise_location(event.get("pass", {}).get("end_location"))
+        carry_end_location = normalise_location(event.get("carry", {}).get("end_location"))
+        shot_end_location = normalise_location(event.get("shot", {}).get("end_location"))
+
+        shot_info = event.get("shot")
+        shot_xg = float(shot_info.get("statsbomb_xg", 0.0)) if shot_info else 0.0
+        shot_outcome = shot_info.get("outcome", {}).get("name") if shot_info else None
+        is_goal = bool(shot_info and shot_outcome == "Goal")
+        if shot_info:
+            if team_id == home_team_id:
+                shots_home += 1
+                xg_home += shot_xg
+                if shot_outcome in {"Saved", "Goal", "ShotOnPost", "SavedToPost"}:
+                    shots_on_target_home += 1
+                if is_goal:
+                    score_home += 1
+            elif team_id == away_team_id:
+                shots_away += 1
+                xg_away += shot_xg
+                if shot_outcome in {"Saved", "Goal", "ShotOnPost", "SavedToPost"}:
+                    shots_on_target_away += 1
+                if is_goal:
+                    score_away += 1
+            shots.append(
+                ShotRecord(
+                    minute=minute,
+                    second=second,
+                    x=location[0],
+                    y=location[1],
+                    xg=shot_xg,
+                    outcome=shot_outcome or "Unknown",
+                    goal=is_goal,
+                    team_side=team_info.side if team_info else "",
+                )
+            )
+
+        possession_team_id = event.get("possession_team", {}).get("id")
+        possession_team_name = event.get("possession_team", {}).get("name")
+        possession_change = False
+        possession_from = previous_possession_team
+        possession_to = possession_team_id
+        if previous_possession_team != possession_team_id:
+            possession_change = previous_possession_team is not None
+            previous_possession_team = possession_team_id
+
+        record = EventRecord(
+            index=index,
+            event_uuid=event_uuid,
+            minute=minute,
+            second=second,
+            timestamp=event.get("timestamp"),
+            team_id=team_id,
+            team_name=team_name,
+            player_id=player_id,
+            player_name=player_name,
+            event_type=event_type,
+            detail=detail,
+            outcome=outcome,
+            possession_team_id=possession_team_id,
+            possession_team_name=possession_team_name,
+            possession_number=event.get("possession"),
+            possession_change=possession_change,
+            possession_from=possession_from,
+            possession_to=possession_to,
+            location=location,
+            end_location=end_location,
+            carry_end_location=carry_end_location,
+            shot_end_location=shot_end_location,
+            shot_xg=shot_xg,
+            shot_outcome=shot_outcome,
+            is_goal=is_goal,
+            score_home=score_home,
+            score_away=score_away,
+            shots_home=shots_home,
+            shots_away=shots_away,
+            shots_on_target_home=shots_on_target_home,
+            shots_on_target_away=shots_on_target_away,
+            xg_home=xg_home,
+            xg_away=xg_away,
+            period=int(event.get("period", 1)),
+            visible_area=freeze_by_event.get(event_uuid, {}).get("visible_area"),
+        )
+        events.append(record)
+
+        freeze_data = freeze_by_event.get(event_uuid, {})
+        for player in freeze_data.get("freeze_frame", []) or []:
+            player_entry = player.get("player") or {}
+            player_id_ff = player_entry.get("id")
+            info = players.get(player_id_ff)
+            freeze_records.append(
+                FreezeFrameRecord(
+                    event_uuid=event_uuid,
+                    player_id=player_id_ff,
+                    player_name=player_entry.get("name"),
+                    team_id=info.team_id if info else None,
+                    team_name=info.team_name if info else None,
+                    side=info.side if info else None,
+                    x=player.get("location", [None, None])[0]
+                    if player.get("location")
+                    else None,
+                    y=player.get("location", [None, None])[1]
+                    if player.get("location")
+                    else None,
+                    teammate=bool(player.get("teammate")),
+                    actor=bool(player.get("actor")),
+                    keeper=bool(player.get("keeper")),
+                )
+            )
+
+    return events, freeze_records, shots
+
+
+def freeze_frames_by_event(freeze_data: List[dict]) -> Dict[str, dict]:
+    mapping: Dict[str, dict] = {}
+    for entry in freeze_data:
+        event_uuid = entry.get("event_uuid")
+        if event_uuid:
+            mapping[event_uuid] = entry
+    return mapping
+
+
+def build_pitch(fig: go.Figure, row: int, col: int, total_cols: int = 2) -> None:
+    axis_index = (row - 1) * total_cols + col
+    scaleanchor = "x" if axis_index == 1 else f"x{axis_index}"
+    fig.update_xaxes(range=[0, 120], showgrid=False, zeroline=False, visible=False, row=row, col=col)
+    fig.update_yaxes(
+        range=[-5, 85],
+        showgrid=False,
+        zeroline=False,
+        visible=False,
+        scaleanchor=scaleanchor,
+        scaleratio=1,
+        row=row,
+        col=col,
+    )
+    fig.add_shape(
+        type="rect",
+        x0=0,
+        y0=0,
+        x1=120,
+        y1=80,
+        line=dict(color="white", width=2),
+        row=row,
+        col=col,
+    )
+    fig.add_shape(
+        type="line",
+        x0=60,
+        y0=0,
+        x1=60,
+        y1=80,
+        line=dict(color="white", width=2),
+        row=row,
+        col=col,
+    )
+    fig.add_shape(
+        type="circle",
+        x0=60 - 9.15,
+        y0=40 - 9.15,
+        x1=60 + 9.15,
+        y1=40 + 9.15,
+        line=dict(color="white", width=2),
+        row=row,
+        col=col,
+    )
+    fig.add_shape(
+        type="circle",
+        x0=60 - 0.5,
+        y0=40 - 0.5,
+        x1=60 + 0.5,
+        y1=40 + 0.5,
+        fillcolor="white",
+        line=dict(color="white", width=1),
+        row=row,
+        col=col,
+    )
+    for side_start in (0, 120):
+        penalty_x0 = 0 if side_start == 0 else 120 - 18
+        penalty_x1 = 18 if side_start == 0 else 120
+        six_x0 = 0 if side_start == 0 else 120 - 6
+        six_x1 = 6 if side_start == 0 else 120
+        spot_x = 11 if side_start == 0 else 120 - 11
+        fig.add_shape(
+            type="rect",
+            x0=penalty_x0,
+            y0=18,
+            x1=penalty_x1,
+            y1=62,
+            line=dict(color="white", width=2),
+            row=row,
+            col=col,
+        )
+        fig.add_shape(
+            type="rect",
+            x0=six_x0,
+            y0=30,
+            x1=six_x1,
+            y1=50,
+            line=dict(color="white", width=2),
+            row=row,
+            col=col,
+        )
+        fig.add_shape(
+            type="circle",
+            x0=spot_x - 0.5,
+            y0=40 - 0.5,
+            x1=spot_x + 0.5,
+            y1=40 + 0.5,
+            fillcolor="white",
+            line=dict(color="white", width=1),
+            row=row,
+            col=col,
+        )
+
+
+def timeline_marker_style(event: EventRecord) -> Tuple[str, float, str]:
+    if event.is_goal:
+        return "#ffd700", 16.0, "star"
+    if event.event_type == "Shot":
+        return "#ff7f0e", 12.0, "triangle-up"
+    if event.possession_change:
+        return "#f0f0f0", 12.0, "x"
+    if event.event_type in {"Foul Won", "Foul Committed"}:
+        return "#bcbd22", 10.0, "square"
+    if event.event_type in {"Pressure", "Duel", "Dribble"}:
+        return "#17becf", 10.0, "diamond"
+    return "#1f77b4", 8.0, "circle"
+
+
+def build_event_summary(event: EventRecord, teams: Dict[int, TeamInfo]) -> str:
+    time_str = f"{event.minute:02d}:{event.second:02d}"
+    team_name = event.team_name or (
+        teams[event.team_id].name if event.team_id in teams else "Unknown"
+    )
+    player_name = event.player_name or "Unknown"
+    detail = f" ({event.detail})" if event.detail else ""
+    shot_extension = ""
+    if event.event_type == "Shot":
+        shot_extension = f" - xG {event.shot_xg:.2f} ({event.shot_outcome})"
+    possession_change = ""
+    if event.possession_change:
+        from_name = teams[event.possession_from].name if event.possession_from in teams else "Unknown"
+        to_name = teams[event.possession_to].name if event.possession_to in teams else "Unknown"
+        possession_change = f"\nPossession: {from_name} ➜ {to_name}"
+    goal_marker = " ⚽" if event.is_goal else ""
+    return (
+        f"{time_str} — {team_name} — {player_name}\n"
+        f"{event.event_type}{detail}{shot_extension}{goal_marker}{possession_change}"
+    )
+
+
+def build_scoreboard_text(event: EventRecord, teams: Dict[int, TeamInfo]) -> str:
+    home_team = next(team for team in teams.values() if team.side == "home")
+    away_team = next(team for team in teams.values() if team.side == "away")
+    possession_name = event.possession_team_name or (
+        teams[event.possession_team_id].name if event.possession_team_id in teams else "N/A"
+    )
+    lines = [
+        f"<b>{home_team.name}</b> {event.score_home} - {event.score_away} <b>{away_team.name}</b>",
+        f"Possession: {possession_name}",
+        f"Shots (on target): {event.shots_home} ({event.shots_on_target_home}) | {event.shots_away} ({event.shots_on_target_away})",
+        f"xG: {event.xg_home:.2f} | {event.xg_away:.2f}",
+    ]
+    if event.event_type == "Shot":
+        lines.append(
+            f"Latest shot: {event.player_name or 'Unknown'} — xG {event.shot_xg:.2f} ({event.shot_outcome})"
+        )
+    return "<br>".join(lines)
+
+
+def split_freeze_players(
+    freeze_entry: List[FreezeFrameRecord],
+    home_color: str,
+    away_color: str,
+) -> Tuple[go.Scatter, go.Scatter]:
+    home_x: List[Optional[float]] = []
+    home_y: List[Optional[float]] = []
+    home_text: List[str] = []
+    home_sizes: List[float] = []
+    home_line_colors: List[str] = []
+    home_line_widths: List[float] = []
+
+    away_x: List[Optional[float]] = []
+    away_y: List[Optional[float]] = []
+    away_text: List[str] = []
+    away_sizes: List[float] = []
+    away_line_colors: List[str] = []
+    away_line_widths: List[float] = []
+
+    for player in freeze_entry:
+        text = player.player_name or "Unknown"
+        if player.side == "home":
+            home_x.append(player.x)
+            home_y.append(player.y)
+            label = text
+            if player.keeper:
+                label = f"{label} (GK)"
+            home_text.append(label)
+            size = 22 if player.actor else 16
+            line_color = "#ffd700" if player.actor else "white"
+            home_sizes.append(size)
+            home_line_colors.append(line_color)
+            home_line_widths.append(3 if player.actor else 1.5)
+        elif player.side == "away":
+            away_x.append(player.x)
+            away_y.append(player.y)
+            label = text
+            if player.keeper:
+                label = f"{label} (GK)"
+            away_text.append(label)
+            size = 22 if player.actor else 16
+            line_color = "#ffd700" if player.actor else "white"
+            away_sizes.append(size)
+            away_line_colors.append(line_color)
+            away_line_widths.append(3 if player.actor else 1.5)
+
+    home_trace = go.Scatter(
+        x=home_x,
+        y=home_y,
+        mode="markers",
+        marker=dict(
+            color=home_color,
+            size=home_sizes,
+            line=dict(color=home_line_colors, width=home_line_widths),
+        ),
+        text=home_text,
+        name="Home team",
+        hovertemplate="%{text}<extra></extra>",
+        showlegend=False,
+    )
+    away_trace = go.Scatter(
+        x=away_x,
+        y=away_y,
+        mode="markers",
+        marker=dict(
+            color=away_color,
+            size=away_sizes,
+            line=dict(color=away_line_colors, width=away_line_widths),
+        ),
+        text=away_text,
+        name="Away team",
+        hovertemplate="%{text}<extra></extra>",
+        showlegend=False,
+    )
+    return home_trace, away_trace
+
+
+def infer_ball_position(event: EventRecord, freeze_entry: List[FreezeFrameRecord]) -> Tuple[Optional[float], Optional[float]]:
+    if event.location != (None, None):
+        return event.location
+    for player in freeze_entry:
+        if player.actor and player.x is not None and player.y is not None:
+            return (player.x, player.y)
+    return (None, None)
+
+
+def build_replay_figure(
+    events: List[EventRecord],
+    freeze_frames: List[FreezeFrameRecord],
+    shots: List[ShotRecord],
+    teams: Dict[int, TeamInfo],
+    match_info: dict,
+) -> go.Figure:
+    freeze_lookup: Dict[str, List[FreezeFrameRecord]] = {}
+    for frame in freeze_frames:
+        freeze_lookup.setdefault(frame.event_uuid, []).append(frame)
+
+    events_with_frames = [event for event in events if event.event_uuid in freeze_lookup]
+    if not events_with_frames:
+        raise ValueError("No events with 360 freeze frames available for this match.")
+
+    home_color = "#1f77b4"
+    away_color = "#d62728"
+
+    timeline_x = [event.match_time_minutes for event in events_with_frames]
+    timeline_y = [0 for _ in events_with_frames]
+    timeline_colors = []
+    timeline_sizes = []
+    timeline_symbols = []
+    for event in events_with_frames:
+        color, size, symbol = timeline_marker_style(event)
+        timeline_colors.append(color)
+        timeline_sizes.append(size)
+        timeline_symbols.append(symbol)
+
+    fig = make_subplots(
+        rows=2,
+        cols=2,
+        specs=[[{"type": "scatter"}, {"type": "scatter"}], [{"type": "scatter"}, {"type": "scatter"}]],
+        column_widths=[0.7, 0.3],
+        row_heights=[0.65, 0.35],
+        vertical_spacing=0.1,
+        horizontal_spacing=0.08,
+        subplot_titles=("Pitch Replay", "Match Centre", "Event Timeline", "Shot Map"),
+    )
+
+    build_pitch(fig, row=1, col=1)
+    build_pitch(fig, row=2, col=2)
+
+    fig.add_trace(
+        go.Scatter(
+            x=timeline_x,
+            y=timeline_y,
+            mode="markers",
+            marker=dict(color=timeline_colors, size=timeline_sizes, symbol=timeline_symbols),
+            text=[build_event_summary(event, teams) for event in events_with_frames],
+            hovertemplate="%{text}<extra></extra>",
+            name="Timeline events",
+        ),
+        row=2,
+        col=1,
+    )
+    fig.update_yaxes(range=[-1, 1], visible=False, row=2, col=1)
+    max_minute = max(event.match_time_minutes for event in events_with_frames)
+    fig.update_xaxes(range=[-1, max_minute + 1], row=2, col=1, title="Minute", showgrid=False)
+
+    home_shots = [shot for shot in shots if shot.team_side == "home"]
+    away_shots = [shot for shot in shots if shot.team_side == "away"]
+    fig.add_trace(
+        go.Scatter(
+            x=[shot.x for shot in home_shots],
+            y=[shot.y for shot in home_shots],
+            mode="markers",
+            marker=dict(
+                color=home_color,
+                size=[10 + (math.sqrt(shot.xg) * 10 if shot.xg > 0 else 8) for shot in home_shots],
+                symbol=["star" if shot.goal else "circle" for shot in home_shots],
+                line=dict(color="white", width=1.5),
+                opacity=0.85,
+            ),
+            name="Home shots",
+            text=[
+                f"{shot.minute:02d}:{shot.second:02d} — xG {shot.xg:.2f} ({shot.outcome})"
+                for shot in home_shots
+            ],
+            hovertemplate="%{text}<extra></extra>",
+        ),
+        row=2,
+        col=2,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=[shot.x for shot in away_shots],
+            y=[shot.y for shot in away_shots],
+            mode="markers",
+            marker=dict(
+                color=away_color,
+                size=[10 + (math.sqrt(shot.xg) * 10 if shot.xg > 0 else 8) for shot in away_shots],
+                symbol=["star" if shot.goal else "circle" for shot in away_shots],
+                line=dict(color="white", width=1.5),
+                opacity=0.85,
+            ),
+            name="Away shots",
+            text=[
+                f"{shot.minute:02d}:{shot.second:02d} — xG {shot.xg:.2f} ({shot.outcome})"
+                for shot in away_shots
+            ],
+            hovertemplate="%{text}<extra></extra>",
+        ),
+        row=2,
+        col=2,
+    )
+
+    first_event = events_with_frames[0]
+    first_freeze = freeze_lookup[first_event.event_uuid]
+    home_players, away_players = split_freeze_players(first_freeze, home_color, away_color)
+    ball_position = infer_ball_position(first_event, first_freeze)
+
+    fig.add_trace(home_players, row=1, col=1)
+    fig.add_trace(away_players, row=1, col=1)
+    fig.add_trace(
+        go.Scatter(
+            x=[ball_position[0]] if ball_position[0] is not None else [None],
+            y=[ball_position[1]] if ball_position[1] is not None else [None],
+            mode="markers",
+            marker=dict(color="#fefefe", size=16, line=dict(color="black", width=2)),
+            name="Ball",
+            hoverinfo="skip",
+            showlegend=False,
+        ),
+        row=1,
+        col=1,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=[60],
+            y=[-5],
+            mode="text",
+            text=[build_event_summary(first_event, teams)],
+            textfont=dict(color="white", size=14),
+            showlegend=False,
+            hoverinfo="none",
+        ),
+        row=1,
+        col=1,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=[0],
+            y=[0],
+            mode="text",
+            text=[build_scoreboard_text(first_event, teams)],
+            textfont=dict(color="white", size=14),
+            showlegend=False,
+            hoverinfo="none",
+        ),
+        row=1,
+        col=2,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=[first_event.match_time_minutes],
+            y=[0],
+            mode="markers",
+            marker=dict(color="#ffff00", size=20, symbol="line-ns-open"),
+            showlegend=False,
+            hoverinfo="skip",
+        ),
+        row=2,
+        col=1,
+    )
+
+    fig.update_xaxes(range=[-1, 1], visible=False, row=1, col=2)
+    fig.update_yaxes(range=[-1, 1], visible=False, row=1, col=2)
+
+    frames = []
+    slider_steps = []
+    for idx, event in enumerate(events_with_frames):
+        freeze_records_for_event = freeze_lookup[event.event_uuid]
+        home_trace, away_trace = split_freeze_players(
+            freeze_records_for_event, home_color, away_color
+        )
+        ball_x, ball_y = infer_ball_position(event, freeze_records_for_event)
+        frame = go.Frame(
+            data=[
+                home_trace,
+                away_trace,
+                go.Scatter(
+                    x=[ball_x] if ball_x is not None else [None],
+                    y=[ball_y] if ball_y is not None else [None],
+                    mode="markers",
+                    marker=dict(color="#fefefe", size=16, line=dict(color="black", width=2)),
+                    showlegend=False,
+                    hoverinfo="skip",
+                ),
+                go.Scatter(
+                    x=[60],
+                    y=[-5],
+                    mode="text",
+                    text=[build_event_summary(event, teams)],
+                    textfont=dict(color="white", size=14),
+                    showlegend=False,
+                    hoverinfo="none",
+                ),
+                go.Scatter(
+                    x=[0],
+                    y=[0],
+                    mode="text",
+                    text=[build_scoreboard_text(event, teams)],
+                    textfont=dict(color="white", size=14),
+                    showlegend=False,
+                    hoverinfo="none",
+                ),
+                go.Scatter(
+                    x=[event.match_time_minutes],
+                    y=[0],
+                    mode="markers",
+                    marker=dict(color="#ffff00", size=20, symbol="line-ns-open"),
+                    showlegend=False,
+                    hoverinfo="skip",
+                ),
+            ],
+            name=str(idx),
+            traces=[3, 4, 5, 6, 7, 8],
+        )
+        frames.append(frame)
+        slider_steps.append(
+            {
+                "args": [[frame.name], {"frame": {"duration": 0, "redraw": True}, "mode": "immediate"}],
+                "label": f"{event.minute:02d}:{event.second:02d} {event.event_type}",
+                "method": "animate",
+            }
+        )
+
+    fig.frames = frames
+
+    fig.update_layout(
+        width=1200,
+        height=800,
+        showlegend=True,
+        legend=dict(bgcolor="rgba(0,0,0,0)", font=dict(color="white")),
+        plot_bgcolor="#0b6623",
+        paper_bgcolor="#123524",
+        font=dict(color="white"),
+        margin=dict(l=40, r=40, t=80, b=40),
+        sliders=[
+            dict(
+                active=0,
+                currentvalue=dict(prefix="Event: ", font=dict(color="white", size=16)),
+                pad=dict(t=30),
+                steps=slider_steps,
+                x=0.1,
+                len=0.7,
+            )
+        ],
+        updatemenus=[
+            dict(
+                type="buttons",
+                direction="left",
+                buttons=[
+                    dict(
+                        label="Play",
+                        method="animate",
+                        args=[[frame.name for frame in frames], {"frame": {"duration": 200, "redraw": True}, "fromcurrent": True}],
+                    ),
+                    dict(label="Pause", method="animate", args=[[None], {"frame": {"duration": 0}, "mode": "immediate"}]),
+                ],
+                pad=dict(t=30, r=10),
+                x=0.85,
+                y=1.07,
+                bgcolor="#1b4332",
+            )
+        ],
+        annotations=[
+            dict(
+                text=(
+                    f"Referee: {match_info.get('referee', {}).get('name', 'Unknown')}<br>"
+                    f"Venue: {match_info.get('stadium', {}).get('name', 'Unknown')}"
+                ),
+                x=0.82,
+                y=0.32,
+                xref="paper",
+                yref="paper",
+                showarrow=False,
+                font=dict(size=12, color="white"),
+            )
+        ],
+    )
+
+    return fig
+
+
+def list_matches_with_three_sixty(
+    manager: DataManager,
+    competition_id: int,
+    season_id: int,
+) -> None:
+    three_sixty_ids = set(manager.list_three_sixty_match_ids())
+    matches = manager.get_matches(competition_id, season_id)
+    rows = []
+    for match in matches:
+        match_id = match.get("match_id")
+        if match_id in three_sixty_ids:
+            rows.append(
+                (
+                    match_id,
+                    match.get("match_date"),
+                    match.get("home_team", {}).get("home_team_name"),
+                    match.get("away_team", {}).get("away_team_name"),
+                    match.get("competition_stage", {}).get("name"),
+                )
+            )
+    if not rows:
+        print("No matches with 360 data found for the selected competition/season.")
+        return
+    header = f"{'Match ID':>8}  {'Date':<12}  {'Home':<25}  {'Away':<25}  {'Stage'}"
+    print(header)
+    print("-" * len(header))
+    for match_id, date, home, away, stage in rows:
+        print(f"{match_id:>8}  {date:<12}  {home:<25}  {away:<25}  {stage}")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an interactive replay for a StatsBomb 360 match.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--competition-id", type=int, required=True, help="StatsBomb competition id")
+    parser.add_argument("--season-id", type=int, required=True, help="StatsBomb season id")
+    parser.add_argument("--match-id", type=int, help="StatsBomb match id")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("match_replay.html"),
+        help="Path to the HTML file that will contain the replay",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data"),
+        help="Directory where downloaded and processed data will be stored",
+    )
+    parser.add_argument(
+        "--list-matches",
+        action="store_true",
+        help="List all matches with 360 data for the selected competition/season and exit",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_arguments()
+    manager = DataManager(args.data_dir)
+
+    if args.list_matches:
+        if args.match_id:
+            print("--match-id is ignored when --list-matches is supplied.")
+        list_matches_with_three_sixty(manager, args.competition_id, args.season_id)
+        return
+
+    if args.match_id is None:
+        raise SystemExit("--match-id is required unless --list-matches is used")
+
+    matches = manager.get_matches(args.competition_id, args.season_id)
+    match_info = None
+    for match in matches:
+        if match.get("match_id") == args.match_id:
+            match_info = match
+            break
+    if match_info is None:
+        raise SystemExit("Match not found in the selected competition/season")
+
+    freeze_data = manager.get_three_sixty(args.match_id)
+    if not freeze_data:
+        raise SystemExit("No 360 data available for this match")
+
+    events_data = manager.get_events(args.match_id)
+    lineups = manager.get_lineups(args.match_id)
+
+    teams = build_team_directory(match_info)
+    players = build_player_directory(lineups, teams)
+    freeze_lookup = freeze_frames_by_event(freeze_data)
+    events, freeze_frames, shots = process_events(events_data, freeze_lookup, players, teams)
+
+    manager.save_processed_dataset(args.match_id, events, freeze_frames)
+
+    figure = build_replay_figure(events, freeze_frames, shots, teams, match_info)
+    figure.write_html(str(args.output), include_plotlyjs="cdn")
+    print(f"Replay saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone `replay_generator.py` utility that downloads StatsBomb open data for a chosen match with 360 freeze frames
- compute enriched event, possession, and shot summaries while caching processed datasets for future modelling work
- build an interactive Plotly HTML replay complete with slider controls, scoreboard panel, event timeline, and shot map

## Testing
- python replay_generator.py --help *(fails: Plotly missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d41c45a1d8832a9673f8f09e1afe60